### PR TITLE
Pc 4538 props geoloc search

### DIFF
--- a/src/components/pages/search/Home/Home.jsx
+++ b/src/components/pages/search/Home/Home.jsx
@@ -15,9 +15,15 @@ export class Home extends PureComponent {
 
   handleOnSubmit = event => {
     event.preventDefault()
-    const { categoryCriterion, geolocationCriterion, history, sortCriterion } = this.props
+    const {
+      categoryCriterion,
+      geolocationCriterion,
+      history,
+      sortCriterion,
+      userGeolocation,
+    } = this.props
     const { keywordsToSearch } = this.state
-    const { place, searchAround, userGeolocation } = geolocationCriterion
+    const { place, searchAround } = geolocationCriterion
     const { geolocation: placeGeolocation, name } = place || {}
     const { long = '' } = name || {}
 
@@ -127,10 +133,6 @@ Home.propTypes = {
       place: PropTypes.bool,
       user: PropTypes.bool,
     }).isRequired,
-    userGeolocation: PropTypes.shape({
-      latitude: PropTypes.number,
-      longitude: PropTypes.number,
-    }),
   }).isRequired,
   history: PropTypes.shape({ push: PropTypes.func }).isRequired,
   sortCriterion: PropTypes.shape({
@@ -138,5 +140,9 @@ Home.propTypes = {
     index: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
     requiresGeolocation: PropTypes.bool.isRequired,
+  }).isRequired,
+  userGeolocation: PropTypes.shape({
+    latitude: PropTypes.number,
+    longitude: PropTypes.number,
   }).isRequired,
 }

--- a/src/components/pages/search/Home/__specs__/Home.spec.jsx
+++ b/src/components/pages/search/Home/__specs__/Home.spec.jsx
@@ -37,10 +37,10 @@ describe('components | Home', () => {
             short: "34 avenue de l'opéra",
           },
         },
-        userGeolocation: {
-          latitude: 40,
-          longitude: 41,
-        },
+      },
+      userGeolocation: {
+        latitude: 40,
+        longitude: 41,
       },
       history: {
         push: jest.fn(),

--- a/src/components/pages/search/Results/Results.jsx
+++ b/src/components/pages/search/Results/Results.jsx
@@ -62,7 +62,7 @@ class Results extends PureComponent {
       numberOfActiveFilters: this.getNumberOfActiveFilters(
         categoriesFromUrlOrProps,
         parametersFromHome,
-        searchAroundFromUrlOrProps,
+        searchAroundFromUrlOrProps
       ),
       place: placeFromUrlOrProps,
       resultsCount: 0,
@@ -70,7 +70,6 @@ class Results extends PureComponent {
       searchedKeywords: '',
       sortCriterionLabel: this.getSortCriterionLabelFromIndex(sortByFromUrlOrProps),
       totalPagesNumber: 0,
-      userGeolocation: props.userGeolocation,
     }
     this.inputRef = React.createRef()
   }
@@ -96,19 +95,22 @@ class Results extends PureComponent {
 
   updateFiltersWhenComingFromHome = (parametersFromHome, keywords, currentPage) => {
     const { filters } = this.state
-    this.setState({
-      filters: {
-        ...filters,
-        ...parametersFromHome,
-        searchAround: {
-          everywhere: !parametersFromHome.searchAround,
-          place: false,
-          user: parametersFromHome.searchAround,
+    this.setState(
+      {
+        filters: {
+          ...filters,
+          ...parametersFromHome,
+          searchAround: {
+            everywhere: !parametersFromHome.searchAround,
+            place: false,
+            user: parametersFromHome.searchAround,
+          },
         },
       },
-    }, () => {
-      this.fetchOffers({ keywords, page: currentPage })
-    })
+      () => {
+        this.fetchOffers({ keywords, page: currentPage })
+      }
+    )
   }
 
   getCategoriesFromUrlOrProps = categoriesFromProps => {
@@ -201,7 +203,8 @@ class Results extends PureComponent {
 
   getNumberOfActiveFilters = (categories, parametersFromHome, searchAround) => {
     const numberOfActiveCategories = categories.length
-    const geolocationFilterCounter = searchAround.user === true || searchAround.place === true ? 1 : 0
+    const geolocationFilterCounter =
+      searchAround.user === true || searchAround.place === true ? 1 : 0
 
     if (parametersFromHome) {
       const {
@@ -213,13 +216,15 @@ class Results extends PureComponent {
         priceRange,
       } = parametersFromHome
 
-      return geolocationFilterCounter
-        + offerCategories.length
-        + this.getNumberFromBoolean(offerIsDuo)
-        + this.getNumberFromBoolean(offerIsFree)
-        + this.getNumberFromBoolean(offerIsNew)
-        + this.getNumberOfSelectedFilters(offerTypes)
-        + this.getPriceRangeCounter(priceRange)
+      return (
+        geolocationFilterCounter +
+        offerCategories.length +
+        this.getNumberFromBoolean(offerIsDuo) +
+        this.getNumberFromBoolean(offerIsFree) +
+        this.getNumberFromBoolean(offerIsNew) +
+        this.getNumberOfSelectedFilters(offerTypes) +
+        this.getPriceRangeCounter(priceRange)
+      )
     }
     return geolocationFilterCounter + numberOfActiveCategories
   }
@@ -271,7 +276,7 @@ class Results extends PureComponent {
         () => {
           const { currentPage } = this.state
           this.fetchOffers({ keywords: trimmedKeywordsToSearch, page: currentPage })
-        },
+        }
       )
     }
     this.inputRef.current.blur()
@@ -306,7 +311,8 @@ class Results extends PureComponent {
   }
 
   fetchOffers = ({ keywords = '', page = 0 } = {}) => {
-    const { filters, place, userGeolocation } = this.state
+    const { filters, place } = this.state
+    const { userGeolocation } = this.props
     const {
       aroundRadius,
       date,
@@ -422,7 +428,7 @@ class Results extends PureComponent {
         results: [],
         sortCriterionLabel: this.getSortCriterionLabelFromIndex(sortBy),
       }),
-      () => this.fetchOffers({ keywords: searchedKeywords }),
+      () => this.fetchOffers({ keywords: searchedKeywords })
     )
     const queryParams = search.replace(/(tri=)(\w*)/, 'tri=' + sortBy)
 
@@ -449,13 +455,13 @@ class Results extends PureComponent {
       () => {
         if (isGeolocationEnabled(userGeolocation)) {
           history.push(
-            `/recherche/resultats?mots-cles=&autour-de=oui&tri=&categories=&latitude=${userGeolocation.latitude}&longitude=${userGeolocation.longitude}`,
+            `/recherche/resultats?mots-cles=&autour-de=oui&tri=&categories=&latitude=${userGeolocation.latitude}&longitude=${userGeolocation.longitude}`
           )
           this.fetchOffers()
         } else {
           window.alert('Active ta géolocalisation pour voir les offres autour de toi !')
         }
-      },
+      }
     )
   }
 
@@ -615,7 +621,13 @@ Results.defaultProps = {
 
 Results.propTypes = {
   criteria: PropTypes.shape({
-    categories: PropTypes.array,
+    categories: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string,
+        icon: PropTypes.string,
+        facetFilter: PropTypes.string,
+      })
+    ),
     searchAround: PropTypes.shape({
       everywhere: PropTypes.bool,
       place: PropTypes.bool,

--- a/src/components/pages/search/Results/__specs__/Results.spec.jsx
+++ b/src/components/pages/search/Results/__specs__/Results.spec.jsx
@@ -2179,10 +2179,6 @@ describe('components | Results', () => {
         searchedKeywords: 'vas-y',
         sortCriterionLabel: 'Pertinence',
         totalPagesNumber: 0,
-        userGeolocation: {
-          latitude: 40.1,
-          longitude: 41.1,
-        },
       })
     })
 

--- a/src/components/pages/search/Search.jsx
+++ b/src/components/pages/search/Search.jsx
@@ -28,7 +28,6 @@ class Search extends PureComponent {
           place: false,
           user: false,
         },
-        userGeolocation: props.geolocation,
       },
       sortCriterion: SORT_CRITERIA.RELEVANCE,
     }
@@ -59,9 +58,6 @@ class Search extends PureComponent {
   }
 
   handleGeolocationCriterionSelection = criterionKey => {
-    const {
-      geolocationCriterion: { userGeolocation },
-    } = this.state
     const label = GEOLOCATION_CRITERIA[criterionKey].label
 
     this.setState({
@@ -73,7 +69,6 @@ class Search extends PureComponent {
           everywhere: label === GEOLOCATION_CRITERIA.EVERYWHERE.label,
           user: label === GEOLOCATION_CRITERIA.AROUND_ME.label,
         },
-        userGeolocation,
       },
     })
     const { redirectToSearchMainPage } = this.props
@@ -81,23 +76,20 @@ class Search extends PureComponent {
   }
 
   handleOnPlaceSelection = place => {
-    this.setState(prevState => {
-      return {
-        geolocationCriterion: {
-          params: {
-            label: buildPlaceLabel(place),
-            icon: 'ico-there',
-            requiresGeolocation: false,
-          },
-          place: place,
-          searchAround: {
-            everywhere: false,
-            place: true,
-            user: false,
-          },
-          userGeolocation: prevState.geolocationCriterion.userGeolocation,
+    this.setState({
+      geolocationCriterion: {
+        params: {
+          label: buildPlaceLabel(place),
+          icon: 'ico-there',
+          requiresGeolocation: false,
         },
-      }
+        place: place,
+        searchAround: {
+          everywhere: false,
+          place: true,
+          user: false,
+        },
+      },
     })
   }
 
@@ -118,11 +110,10 @@ class Search extends PureComponent {
   }
 
   render() {
-    const { history, location, match, redirectToSearchMainPage } = this.props
+    const { history, location, match, redirectToSearchMainPage, geolocation } = this.props
     const { categoryCriterion, geolocationCriterion, sortCriterion } = this.state
-    const { place, userGeolocation } = geolocationCriterion
+    const { place } = geolocationCriterion
     const { parametersFromHome } = location
-
     return (
       <Switch>
         <Route
@@ -134,7 +125,7 @@ class Search extends PureComponent {
             geolocationCriterion={geolocationCriterion}
             history={history}
             sortCriterion={sortCriterion}
-            userGeolocation={userGeolocation}
+            userGeolocation={geolocation}
           />
         </Route>
         <Route path={`${match.path}/resultats`}>
@@ -151,7 +142,7 @@ class Search extends PureComponent {
             place={place}
             redirectToSearchMainPage={redirectToSearchMainPage}
             search={history.location.search}
-            userGeolocation={userGeolocation}
+            userGeolocation={geolocation}
           />
         </Route>
         <Route path={`${match.path}/criteres-localisation`}>
@@ -159,7 +150,7 @@ class Search extends PureComponent {
             activeCriterionLabel={geolocationCriterion.params.label}
             backTo={match.path}
             criteria={GEOLOCATION_CRITERIA}
-            geolocation={userGeolocation}
+            geolocation={geolocation}
             history={history}
             match={match}
             onCriterionSelection={this.handleGeolocationCriterionSelection}
@@ -184,7 +175,7 @@ class Search extends PureComponent {
             activeCriterionLabel={sortCriterion.label}
             backTo={match.path}
             criteria={SORT_CRITERIA}
-            geolocation={userGeolocation}
+            geolocation={geolocation}
             history={history}
             match={match}
             onCriterionSelection={this.handleSortCriterionSelection}

--- a/src/components/pages/search/__specs__/Search.spec.jsx
+++ b/src/components/pages/search/__specs__/Search.spec.jsx
@@ -52,7 +52,7 @@ describe('components | Search', () => {
 
       // Then
       expect(document.querySelector().content).toMatch(
-        'height=123px, width=device-width, initial-scale=1, user-scalable=no, shrink-to-fit=no',
+        'height=123px, width=device-width, initial-scale=1, user-scalable=no, shrink-to-fit=no'
       )
     })
 
@@ -68,7 +68,7 @@ describe('components | Search', () => {
       // Then
       expect(window.onresize).toBeNull()
       expect(document.querySelector().content).toBe(
-        'width=device-width, initial-scale=1, user-scalable=no, shrink-to-fit=no',
+        'width=device-width, initial-scale=1, user-scalable=no, shrink-to-fit=no'
       )
     })
 
@@ -78,7 +78,7 @@ describe('components | Search', () => {
       const wrapper = mount(
         <Router history={props.history}>
           <Search {...props} />
-        </Router>,
+        </Router>
       )
 
       // when
@@ -94,7 +94,7 @@ describe('components | Search', () => {
       const wrapper = mount(
         <Router history={props.history}>
           <Search {...props} />
-        </Router>,
+        </Router>
       )
 
       // when
@@ -110,7 +110,7 @@ describe('components | Search', () => {
       const wrapper = mount(
         <Router history={props.history}>
           <Search {...props} />
-        </Router>,
+        </Router>
       )
 
       // when
@@ -150,10 +150,6 @@ describe('components | Search', () => {
             place: false,
             user: false,
           },
-          userGeolocation: {
-            latitude: 32,
-            longitude: 45,
-          },
         })
         expect(home.prop('history')).toStrictEqual(props.history)
         expect(home.prop('sortCriterion')).toStrictEqual({
@@ -187,7 +183,7 @@ describe('components | Search', () => {
         expect(searchResultsComponent.prop('match')).toStrictEqual(props.match)
         expect(searchResultsComponent.prop('parse')).toStrictEqual(parse)
         expect(searchResultsComponent.prop('redirectToSearchMainPage')).toStrictEqual(
-          props.redirectToSearchMainPage,
+          props.redirectToSearchMainPage
         )
         expect(searchResultsComponent.prop('search')).toStrictEqual(props.history.location.search)
         expect(searchResultsComponent.prop('userGeolocation')).toStrictEqual(props.geolocation)
@@ -236,7 +232,7 @@ describe('components | Search', () => {
         expect(searchResultsComponent.prop('parametersFromHome')).toStrictEqual({ isDuo: true })
         expect(searchResultsComponent.prop('parse')).toStrictEqual(parse)
         expect(searchResultsComponent.prop('redirectToSearchMainPage')).toStrictEqual(
-          props.redirectToSearchMainPage,
+          props.redirectToSearchMainPage
         )
         expect(searchResultsComponent.prop('search')).toStrictEqual(props.history.location.search)
         expect(searchResultsComponent.prop('userGeolocation')).toStrictEqual(props.geolocation)
@@ -263,7 +259,7 @@ describe('components | Search', () => {
         expect(searchCriteriaLocation.prop('history')).toStrictEqual(props.history)
         expect(searchCriteriaLocation.prop('match')).toStrictEqual(props.match)
         expect(searchCriteriaLocation.prop('onCriterionSelection')).toStrictEqual(
-          expect.any(Function),
+          expect.any(Function)
         )
         expect(searchCriteriaLocation.prop('onPlaceSelection')).toStrictEqual(expect.any(Function))
         expect(searchCriteriaLocation.prop('place')).toBeNull()
@@ -276,7 +272,7 @@ describe('components | Search', () => {
         const wrapper = mount(
           <Router history={props.history}>
             <Search {...props} />
-          </Router>,
+          </Router>
         )
         const everywhereButton = wrapper.find({ children: 'Partout' })
 


### PR DESCRIPTION
Vu avec @apibrac 

Ticket jira: https://passculture.atlassian.net/secure/RapidBoard.jspa?rapidView=16&modal=detail&selectedIssue=PC-4538

On a remarqué que certains composants ne prenaient pas en compte les mise à jour de la prop géoloc (version ini stockée dans le state) Cette observation pourrait être liée au bug du ticket associé.

L'idée est de tester si on arrive à reproduire le bug (de ce qu'on m'a dit - pas reproductible en local et aléatoire à reproduire autrement) avec un fix du genre de cette PR. Si la résolution est KO, on pourrait ré-ouvrir la PR https://github.com/pass-culture/pass-culture-browser/pull/1831 qui devrait assurer que le bug ne se reproduise pas.

Merci d'avance pour vos retours !
