### PR TITLE
Pc 5043 fix geoloc homepage

### DIFF
--- a/src/components/pages/home/Home.jsx
+++ b/src/components/pages/home/Home.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Fragment, useState } from 'react'
+import React, { Fragment, useEffect, useRef, useState } from 'react'
 import MainView from './MainView/MainView'
 import User from './Profile/ValueObjects/User'
 import { getCurrentPosition } from '../../../utils/geolocation'
@@ -15,16 +15,27 @@ const Home = ({
   user,
 }) => {
   const [isLoading, setIsLoading] = useState(true)
-  const userCoordinates = getCurrentPosition(geolocation).then(userCoordinates => {
-    setIsLoading(false)
-    return userCoordinates
-  })
+  const geolocationRef = useRef(geolocation)
+
+  useEffect(() => {
+    const waitForCoordinates = async () => {
+      try {
+        const confirmedGeolocation = await getCurrentPosition(geolocation)
+        geolocationRef.current = confirmedGeolocation
+        setIsLoading(false)
+      } catch (error) {
+        setIsLoading(false)
+      }
+    }
+    waitForCoordinates()
+  }, [geolocation])
+
   return (
     <Fragment>
       {isLoading && <LoaderContainer />}
       {!isLoading && (
         <MainView
-          geolocation={userCoordinates}
+          geolocation={geolocationRef.current}
           history={history}
           match={match}
           trackAllModulesSeen={trackAllModulesSeen}

--- a/src/components/pages/home/__specs__/Home.spec.jsx
+++ b/src/components/pages/home/__specs__/Home.spec.jsx
@@ -77,6 +77,35 @@ describe('src | components | home', () => {
     expect(loadingScreen).toHaveLength(1)
   })
 
+  it('should render the main view with a valid geolocation prop', async () => {
+    // Given
+    const flushPromises = () => new Promise(setImmediate)
+    fetchAlgolia.mockReturnValue(
+      new Promise(resolve => {
+        resolve({
+          hits: [],
+          nbHits: 0,
+          nbPages: 1,
+          page: 1,
+        })
+      })
+    )
+    fetchHomepage.mockResolvedValue([])
+
+    // When
+    const wrapper = await mount(
+      <MemoryRouter initialEntries={['/accueil']}>
+        <Home {...props} />
+      </MemoryRouter>
+    )
+    await flushPromises()
+    wrapper.update()
+
+    // Then
+    const mainView = wrapper.find('MainView')
+    expect(mainView.prop('geolocation')).toStrictEqual(props.geolocation)
+  })
+
   it('should render the main view when navigating to /accueil', async () => {
     // Given
     const flushPromises = () => new Promise(setImmediate)


### PR DESCRIPTION
Le problème venait du fait que la promesse de la géoloc était transmise de la `Home` vers la `MainView` au lieu du résultat de cette promesse. 

Ce qui était transmis: (logs du navigateur)
``` javascript
Promise {<fulfilled>: {…}}
  __proto__: Promise
  [[PromiseState]]: "fulfilled"
  [[PromiseResult]]: Object
    latitude: 48.849919799999995
    longitude: 2.6370411
    watchId: 1
```

Ce qui est maintenant transmis: (logs du navigateur)
```javascript
{latitude: 48.849919799999995, longitude: 2.6370411, watchId: 1}
  latitude: 48.849919799999995
  longitude: 2.6370411
  watchId: 1
``` 