### PR TITLE
(PC-5686) Correction des events Matomo qui sont déclenchés deux fois lorsqu'on change de page

### DIFF
--- a/src/components/matomo/Matomo.js
+++ b/src/components/matomo/Matomo.js
@@ -21,15 +21,15 @@ const Matomo = ({ history, location, userId }) => {
   }
 
   useEffect(() => {
-    trackPageView()
+    trackPageView() // called on first render
     const unlisten = history.listen(() => {
-      trackPageView()
+      trackPageView() // called on every page change BUT NOT on first render
     })
 
     return () => {
       unlisten()
     }
-  })
+  }, [history])
 
   if (location.pathname == '/connexion') {
     Matomo.push(['resetUserId'])


### PR DESCRIPTION
**Lien du ticket Jira** : https://passculture.atlassian.net/browse/PC-5686

**Tests de non-régressions ajoutés** : 👍🏻 

**Cause du bug** : 
- Modification qui a introduit la régression :  https://github.com/pass-culture/pass-culture-browser/pull/1841/commits/151016548a71b0c751ce39755cdeb2e1981c20c0#diff-bca93667e42cff08b290230e2c0b287353818b23caccbb8c6ab2fa7bc3f8ee1aR32
- Explication : sans dépendances, le `useEffect` est exécuté une nouvelle fois au moment du changement de page. On a ainsi deux trigger d'events : le `useEffect` + le listener de changement de route sur `history`.