### PR TITLE
(PC-5739) Déclencher l'event AllModulesSeen uniquement lorsque l'utilisateur a scrollé jusqu'au dernier module (tout en bas) de la home page

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,7 @@
     "jest/prefer-inline-snapshots": "off",
     "jsx-a11y/label-has-for": "off",
     "no-var": "error",
+    "react/destructuring-assignment": "off",
     "react/forbid-component-props": "off",
     "react/function-component-definition":  [
       2,


### PR DESCRIPTION
**Lien du ticket Jira** : https://passculture.atlassian.net/browse/PC-5739

**Tests de non-régressions ajoutés** : ❌ 

**Bug** : l'event AllModulesSeen est déclenché dès l'arrivée sur la home page.

**Cause du bug** : le calcul pour déterminer si l'utilisateur a scrollé tout en bas de la page est effectué alors même que tous les modules n'ont pas encore été peints sur l'écran. Ainsi, il est évident que lors qu’aucun module n'est peint, l'utilisateur est initialement en bas de la page (un classique 🎼 ).

 **Fix**  : placer les modules dans leur propre composant. Modifier la valeur d'un flag boolean au render de ces modules durant l'execution d'un hook useEffect. Ce flag est utilisé pour déclencher le calcul pour déterminer si l'utilisateur a scrollé tout en bas de la page.