### PR TITLE
(PC-5739) Tracking systématique du AllModuleSeen

### DIFF
--- a/src/components/layout/Booking/BookingContainer.js
+++ b/src/components/layout/Booking/BookingContainer.js
@@ -25,8 +25,7 @@ export const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export const mapDispatchToProps = dispatch => (
-  {
+export const mapDispatchToProps = dispatch => ({
   handleSubmit: (payload, handleRequestFail, handleRequestSuccess) => {
     dispatch(
       requestData({
@@ -43,11 +42,15 @@ export const mapDispatchToProps = dispatch => (
   getCurrentUserInformation: async () => {
     const currentUser = await getCurrentUser()
     return dispatch(setCurrentUser(currentUser))
-  }
+  },
 })
 
 export const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const { history: { location: { pathname }}} = ownProps
+  const {
+    history: {
+      location: { pathname },
+    },
+  } = ownProps
   const basePathRegExp = '^/([^/]*)/'
   const basePath = pathname.match(basePathRegExp)[1]
   const { offer: { id: offerId } = {} } = stateProps
@@ -57,7 +60,10 @@ export const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...dispatchProps,
     ...ownProps,
     trackBookingSuccess: () => {
-      ownProps.tracking.trackEvent({ action: `${basePath.toUpperCase()} - bookingOffer`, name: offerId })
+      ownProps.tracking.trackEvent({
+        action: `${basePath.toUpperCase()} - bookingOffer`,
+        name: offerId,
+      })
     },
   }
 }
@@ -65,9 +71,5 @@ export const mergeProps = (stateProps, dispatchProps, ownProps) => {
 export default compose(
   withRouter,
   withTracking('Offer'),
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  )
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)
 )(Booking)

--- a/src/components/pages/home/Home.jsx
+++ b/src/components/pages/home/Home.jsx
@@ -19,7 +19,7 @@ const Home = ({
   user,
 }) => {
   const geolocationRef = useRef(geolocation)
-  const { displayedModules, fetchingError, algoliaMapping } = useDisplayedHomemodules(
+  const { displayedModules, isError, isLoading, algoliaMapping } = useDisplayedHomemodules(
     history,
     geolocationRef.current
   )
@@ -40,8 +40,8 @@ const Home = ({
     waitForCoordinates()
   }, [geolocation])
 
-  if (fetchingError) return <AnyError />
-  if (Object.entries(algoliaMapping).length === 0) return <LoaderContainer />
+  if (isError) return <AnyError />
+  if (isLoading) return <LoaderContainer />
 
   return (
     <MainView

--- a/src/components/pages/home/Home.jsx
+++ b/src/components/pages/home/Home.jsx
@@ -68,7 +68,7 @@ Home.propTypes = {
   trackAllModulesSeen: PropTypes.func.isRequired,
   trackAllTilesSeen: PropTypes.func.isRequired,
   updateCurrentUser: PropTypes.func.isRequired,
-  user: PropTypes.instanceOf(User).isRequired,
+  user: PropTypes.shape(User).isRequired,
 }
 
 export default Home

--- a/src/components/pages/home/MainView/MainView.jsx
+++ b/src/components/pages/home/MainView/MainView.jsx
@@ -151,7 +151,7 @@ MainView.propTypes = {
     })
   ).isRequired,
   displayedModules: PropTypes.arrayOf(
-    PropTypes.instanceOf(Offers, OffersWithCover, BusinessPane, ExclusivityPane)
+    PropTypes.shape(Offers, OffersWithCover, BusinessPane, ExclusivityPane)
   ).isRequired,
   geolocation: PropTypes.shape({
     latitude: PropTypes.number,

--- a/src/components/pages/home/MainView/MainView.jsx
+++ b/src/components/pages/home/MainView/MainView.jsx
@@ -143,13 +143,13 @@ const MainView = props => {
 }
 
 MainView.propTypes = {
-  algoliaMapping: {
-    moduleId: PropTypes.shape({
+  algoliaMapping: PropTypes.shape(
+    PropTypes.shape({
       hits: PropTypes.arrayOf(PropTypes.shape()).isRequired,
       nbHits: PropTypes.number.isRequired,
       parsedParameters: PropTypes.shape(),
-    }),
-  }.isRequired,
+    })
+  ).isRequired,
   displayedModules: PropTypes.arrayOf(
     PropTypes.instanceOf(Offers, OffersWithCover, BusinessPane, ExclusivityPane)
   ).isRequired,

--- a/src/components/pages/home/MainView/MainView.jsx
+++ b/src/components/pages/home/MainView/MainView.jsx
@@ -25,8 +25,8 @@ const MainView = props => {
   const { trackAllModulesSeen, trackAllTilesSeen } = props
   const [modules, setModules] = useState([])
   const [fetchingError, setFetchingError] = useState(false)
-  const [haveSeenAllModules, setHaveSeenAllModules] = useState(false)
 
+  const haveSeenAllModules = useRef(false)
   const modulesListRef = useRef(null)
 
   useEffect(() => {
@@ -41,13 +41,8 @@ const MainView = props => {
       .catch(() => setFetchingError(true))
   }, [history.location.search])
 
-  useEffect(() => {
-    if (haveSeenAllModules) {
-      trackAllModulesSeen(modules.length)
-    }
-  }, [haveSeenAllModules, trackAllModulesSeen, modules.length])
-
   const checkIfAllModulesHaveBeenSeen = useCallback(() => {
+    if (!modulesListRef.current || haveSeenAllModules.current) return
     const navbarHeight = 60
     const modulePaddingBottom = 24
     const hasReachedEndOfPage =
@@ -56,10 +51,11 @@ const MainView = props => {
         modulePaddingBottom -
         document.documentElement.clientHeight <=
       0
-    if (hasReachedEndOfPage) {
-      setHaveSeenAllModules(true)
+    if (hasReachedEndOfPage && modulesListRef.current.children.length > 0) {
+      trackAllModulesSeen()
+      haveSeenAllModules.current = true
     }
-  }, [])
+  }, [trackAllModulesSeen])
 
   const renderModule = (module, row) => {
     if (module instanceof Offers || module instanceof OffersWithCover) {

--- a/src/components/pages/home/MainView/MainView.jsx
+++ b/src/components/pages/home/MainView/MainView.jsx
@@ -48,10 +48,10 @@ const MainView = props => {
         document.documentElement.clientHeight <=
       0
     if (hasReachedEndOfPage && modulesListRef.current.children.length > 0) {
-      trackAllModulesSeen()
+      trackAllModulesSeen(displayedModules.length)
       haveSeenAllModules.current = true
     }
-  }, [trackAllModulesSeen])
+  }, [trackAllModulesSeen, displayedModules])
 
   useEffect(() => {
     // Check on first render if we have seen all modules without scrolling: all modules fit on the page

--- a/src/components/pages/home/MainView/Module/Module.jsx
+++ b/src/components/pages/home/MainView/Module/Module.jsx
@@ -42,6 +42,7 @@ const Module = props => {
     ? buildTiles({ algolia, cover, hits, nbHits })
     : buildPairedTiles({ algolia, cover, hits, nbHits })
 
+  const LayoutComponent = isOneItemLayout ? OneItem : TwoItems
   return (
     <section className="module-wrapper">
       <h1>
@@ -59,33 +60,19 @@ const Module = props => {
           resistance
           slideClassName="module-slides"
         >
-          {tiles.map((tile, index) => {
-            return isOneItemLayout ? (
-              <OneItem
-                historyPush={historyPush}
-                isSwitching={isSwitching}
-                // eslint-disable-next-line react/no-array-index-key
-                key={`${index}-tile`}
-                layout={layout}
-                moduleName={title}
-                parsedParameters={parsedParameters}
-                row={row}
-                tile={tile}
-              />
-            ) : (
-              <TwoItems
-                historyPush={historyPush}
-                isSwitching={isSwitching}
-                // eslint-disable-next-line react/no-array-index-key
-                key={`${index}-tile`}
-                layout={layout}
-                moduleName={title}
-                parsedParameters={parsedParameters}
-                row={row}
-                tile={tile}
-              />
-            )
-          })}
+          {tiles.map((tile, index) => (
+            <LayoutComponent
+              historyPush={historyPush}
+              isSwitching={isSwitching}
+              // eslint-disable-next-line react/no-array-index-key
+              key={`${index}-tile`}
+              layout={layout}
+              moduleName={title}
+              parsedParameters={parsedParameters}
+              row={row}
+              tile={tile}
+            />
+          ))}
         </SwipeableViews>
       </ul>
     </section>

--- a/src/components/pages/home/MainView/Module/Module.jsx
+++ b/src/components/pages/home/MainView/Module/Module.jsx
@@ -1,10 +1,8 @@
 import PropTypes from 'prop-types'
-import React, { useCallback, useState, useEffect, useRef } from 'react'
+import React, { useCallback, useState, useRef } from 'react'
 import SwipeableViews from 'react-swipeable-views'
 
-import { fetchAlgolia } from '../../../../../vendor/algolia/algolia'
 import { PANE_LAYOUT } from '../domain/layout'
-import { parseAlgoliaParameters } from '../domain/parseAlgoliaParameters'
 import Offers from '../domain/ValueObjects/Offers'
 import OffersWithCover from '../domain/ValueObjects/OffersWithCover'
 import { buildPairedTiles, buildTiles } from './domain/buildTiles'
@@ -14,30 +12,14 @@ import TwoItems from './TwoItems/TwoItems'
 const swipeRatio = 0.2
 
 const Module = props => {
-  const { geolocation, historyPush, row, module, trackAllTilesSeen } = props
+  const { historyPush, row, module, trackAllTilesSeen, results } = props
   const { algolia, cover, display } = module
-  const [results, setResults] = useState({ hits: [], nbHits: 0, parsedParameters: null })
 
   const [isSwitching, setIsSwitching] = useState(false)
   const onSwitching = useCallback(() => setIsSwitching(true), [])
   const onTransitionEnd = useCallback(() => setIsSwitching(false), [])
 
   const haveAlreadySeenAllTiles = useRef(false)
-
-  useEffect(() => {
-    const parsedParameters = parseAlgoliaParameters({ geolocation, parameters: algolia })
-
-    if (parsedParameters) {
-      fetchAlgolia(parsedParameters).then(data => {
-        const { hits, nbHits } = data
-        setResults({
-          hits: hits,
-          nbHits: nbHits,
-          parsedParameters: parsedParameters,
-        })
-      })
-    }
-  }, [algolia, geolocation])
 
   const onChangeIndex = useCallback(
     numberOfTiles => index => {
@@ -53,79 +35,71 @@ const Module = props => {
     [module, trackAllTilesSeen]
   )
 
-  const { layout = PANE_LAYOUT['ONE-ITEM-MEDIUM'], minOffers = 0, title } = display || {}
-  const { hits, nbHits, parsedParameters } = results
-  const atLeastOneHit = hits.length > 0
-  const minOffersHasBeenReached = nbHits >= minOffers
-  const shouldModuleBeDisplayed = atLeastOneHit && minOffersHasBeenReached
+  const { layout = PANE_LAYOUT['ONE-ITEM-MEDIUM'], title } = display || {}
+  const { hits = [], nbHits = 0, parsedParameters = null } = results || {}
   const isOneItemLayout = layout === PANE_LAYOUT['ONE-ITEM-MEDIUM']
   const tiles = isOneItemLayout
     ? buildTiles({ algolia, cover, hits, nbHits })
     : buildPairedTiles({ algolia, cover, hits, nbHits })
 
   return (
-    shouldModuleBeDisplayed && (
-      <section className="module-wrapper">
-        <h1>
-          {title}
-        </h1>
-        <ul>
-          <SwipeableViews
-            className={layout || PANE_LAYOUT['ONE-ITEM-MEDIUM']}
-            disableLazyLoading
-            enableMouseEvents
-            hysteresis={swipeRatio}
-            onChangeIndex={onChangeIndex(tiles.length)}
-            onSwitching={onSwitching}
-            onTransitionEnd={onTransitionEnd}
-            resistance
-            slideClassName="module-slides"
-          >
-            {tiles.map((tile, index) => {
-              return isOneItemLayout ? (
-                <OneItem
-                  historyPush={historyPush}
-                  isSwitching={isSwitching}
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={`${index}-tile`}
-                  layout={layout}
-                  moduleName={title}
-                  parsedParameters={parsedParameters}
-                  row={row}
-                  tile={tile}
-                />
-              ) : (
-                <TwoItems
-                  historyPush={historyPush}
-                  isSwitching={isSwitching}
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={`${index}-tile`}
-                  layout={layout}
-                  moduleName={title}
-                  parsedParameters={parsedParameters}
-                  row={row}
-                  tile={tile}
-                />
-              )
-            })}
-          </SwipeableViews>
-        </ul>
-      </section>
-    )
+    <section className="module-wrapper">
+      <h1>
+        {title}
+      </h1>
+      <ul>
+        <SwipeableViews
+          className={layout || PANE_LAYOUT['ONE-ITEM-MEDIUM']}
+          disableLazyLoading
+          enableMouseEvents
+          hysteresis={swipeRatio}
+          onChangeIndex={onChangeIndex(tiles.length)}
+          onSwitching={onSwitching}
+          onTransitionEnd={onTransitionEnd}
+          resistance
+          slideClassName="module-slides"
+        >
+          {tiles.map((tile, index) => {
+            return isOneItemLayout ? (
+              <OneItem
+                historyPush={historyPush}
+                isSwitching={isSwitching}
+                // eslint-disable-next-line react/no-array-index-key
+                key={`${index}-tile`}
+                layout={layout}
+                moduleName={title}
+                parsedParameters={parsedParameters}
+                row={row}
+                tile={tile}
+              />
+            ) : (
+              <TwoItems
+                historyPush={historyPush}
+                isSwitching={isSwitching}
+                // eslint-disable-next-line react/no-array-index-key
+                key={`${index}-tile`}
+                layout={layout}
+                moduleName={title}
+                parsedParameters={parsedParameters}
+                row={row}
+                tile={tile}
+              />
+            )
+          })}
+        </SwipeableViews>
+      </ul>
+    </section>
   )
 }
 
-Module.defaultProps = {
-  geolocation: {
-    latitude: null,
-    longitude: null,
-  },
-}
-
 Module.propTypes = {
-  geolocation: PropTypes.shape(),
   historyPush: PropTypes.func.isRequired,
   module: PropTypes.instanceOf(Offers, OffersWithCover).isRequired,
+  results: PropTypes.shape({
+    hits: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+    nbHits: PropTypes.number.isRequired,
+    parsedParameters: PropTypes.shape(),
+  }).isRequired,
   row: PropTypes.number.isRequired,
   trackAllTilesSeen: PropTypes.func.isRequired,
 }

--- a/src/components/pages/home/MainView/__specs__/MainView.spec.jsx
+++ b/src/components/pages/home/MainView/__specs__/MainView.spec.jsx
@@ -278,17 +278,11 @@ describe('src | components | MainView', () => {
   describe('modules tracking', () => {
     it('should track the user who have seen all modules after scroll', async () => {
       // Given
-      fetchHomepage.mockResolvedValueOnce([
-        new BusinessPane({
-          title: 'my-title-1',
-        }),
-        new BusinessPane({
-          title: 'my-title-2',
-        }),
-        new BusinessPane({
-          title: 'my-title-3',
-        }),
-      ])
+      props.displayedModules = [
+        new BusinessPane({ image: 'my-image-1' }),
+        new BusinessPane({ image: 'my-image-2' }),
+        new BusinessPane({ image: 'my-image-3' }),
+      ]
       const wrapper = await mount(
         <MemoryRouter>
           <MainView {...props} />
@@ -308,17 +302,11 @@ describe('src | components | MainView', () => {
 
     it('should not track the user who have not seen all modules after scroll', async () => {
       // Given
-      fetchHomepage.mockResolvedValueOnce([
-        new BusinessPane({
-          title: 'my-title-1',
-        }),
-        new BusinessPane({
-          title: 'my-title-2',
-        }),
-        new BusinessPane({
-          title: 'my-title-3',
-        }),
-      ])
+      props.displayedModules = [
+        new BusinessPane({ image: 'my-image-1' }),
+        new BusinessPane({ image: 'my-image-2' }),
+        new BusinessPane({ image: 'my-image-3' }),
+      ]
       const wrapper = await mount(
         <MemoryRouter>
           <MainView {...props} />
@@ -338,17 +326,12 @@ describe('src | components | MainView', () => {
 
     it('should track the user who have seen all modules without scroll', async () => {
       // Given
-      fetchHomepage.mockResolvedValueOnce([
-        new BusinessPane({
-          title: 'my-title-1',
-        }),
-        new BusinessPane({
-          title: 'my-title-2',
-        }),
-        new BusinessPane({
-          title: 'my-title-3',
-        }),
-      ])
+      props.algoliaMapping = {}
+      props.displayedModules = [
+        new BusinessPane({ image: 'my-image-1' }),
+        new BusinessPane({ image: 'my-image-2' }),
+        new BusinessPane({ image: 'my-image-3' }),
+      ]
       jest.spyOn(document.documentElement, 'clientHeight', 'get').mockImplementationOnce(() => 37)
 
       // When
@@ -364,17 +347,11 @@ describe('src | components | MainView', () => {
 
     it('should not track the user who have not seen all modules without scroll', async () => {
       // Given
-      fetchHomepage.mockResolvedValueOnce([
-        new BusinessPane({
-          title: 'my-title-1',
-        }),
-        new BusinessPane({
-          title: 'my-title-2',
-        }),
-        new BusinessPane({
-          title: 'my-title-3',
-        }),
-      ])
+      props.displayedModules = [
+        new BusinessPane({ image: 'my-image-1' }),
+        new BusinessPane({ image: 'my-image-2' }),
+        new BusinessPane({ image: 'my-image-3' }),
+      ]
       jest.spyOn(document.documentElement, 'clientHeight', 'get').mockImplementationOnce(() => 35)
 
       // When
@@ -413,11 +390,7 @@ describe('src | components | MainView', () => {
         }
       ) => state,
     })
-    fetchHomepage.mockResolvedValueOnce([
-      new BusinessPane({
-        title: 'my-title-1',
-      }),
-    ])
+    props.displayedModules = [new BusinessPane({ image: 'my-image-1' })]
 
     // When
     const wrapper = await mount(

--- a/src/components/pages/home/MainView/__specs__/MainView.spec.jsx
+++ b/src/components/pages/home/MainView/__specs__/MainView.spec.jsx
@@ -48,6 +48,8 @@ describe('src | components | MainView', () => {
     fetchHomepage.mockResolvedValue([])
     parse.mockReturnValue({})
     props = {
+      algoliaMapping: {},
+      displayedModules: [],
       geolocation: {
         latitude: 5,
         longitude: 10,

--- a/src/components/pages/home/MainView/__specs__/MainView.spec.jsx
+++ b/src/components/pages/home/MainView/__specs__/MainView.spec.jsx
@@ -276,7 +276,7 @@ describe('src | components | MainView', () => {
   })
 
   describe('modules tracking', () => {
-    it('should track the user who have seen all modules after scroll', async () => {
+    it('should track the user who have seen all modules after scroll - only once', async () => {
       // Given
       props.displayedModules = [
         new BusinessPane({ image: 'my-image-1' }),
@@ -298,6 +298,14 @@ describe('src | components | MainView', () => {
 
       // Then
       expect(props.trackAllModulesSeen).toHaveBeenCalledWith(3)
+      expect(props.trackAllModulesSeen).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        homeWrapper.invoke('onScroll')()
+      })
+
+      // Then
+      expect(props.trackAllModulesSeen).toHaveBeenCalledTimes(1)
     })
 
     it('should not track the user who have not seen all modules after scroll', async () => {

--- a/src/components/pages/home/MainView/__specs__/MainView.spec.jsx
+++ b/src/components/pages/home/MainView/__specs__/MainView.spec.jsx
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme'
 import { parse } from 'query-string'
 import React from 'react'
+import { act } from 'react-dom/test-utils'
 import { MemoryRouter } from 'react-router'
 
 import { fetchHomepage } from '../../../../../vendor/contentful/contentful'
@@ -325,7 +326,9 @@ describe('src | components | MainView', () => {
 
       // When
       const homeWrapper = wrapper.find('div').first()
-      homeWrapper.invoke('onScroll')()
+      act(() => {
+        homeWrapper.invoke('onScroll')()
+      })
 
       // Then
       expect(props.trackAllModulesSeen).toHaveBeenCalledWith(3)
@@ -353,7 +356,9 @@ describe('src | components | MainView', () => {
 
       // When
       const homeWrapper = wrapper.find('div').first()
-      homeWrapper.invoke('onScroll')()
+      act(() => {
+        homeWrapper.invoke('onScroll')()
+      })
 
       // Then
       expect(props.trackAllModulesSeen).not.toHaveBeenCalled()

--- a/src/components/pages/home/MainView/domain/ValueObjects/Offers.js
+++ b/src/components/pages/home/MainView/domain/ValueObjects/Offers.js
@@ -1,6 +1,7 @@
 export default class Offers {
-  constructor({ algolia, display }) {
+  constructor({ algolia, display, moduleId }) {
     this.algolia = algolia
     this.display = display
+    this.moduleId = moduleId
   }
 }

--- a/src/components/pages/home/MainView/domain/ValueObjects/OffersWithCover.js
+++ b/src/components/pages/home/MainView/domain/ValueObjects/OffersWithCover.js
@@ -1,8 +1,8 @@
 import Offers from './Offers'
 
 export default class OffersWithCover extends Offers {
-  constructor({ algolia = {}, cover = '', display = {} }) {
-    super({algolia, display})
+  constructor({ algolia = {}, cover = '', display = {}, moduleId = '' }) {
+    super({ algolia, display, moduleId })
     this.cover = cover
   }
 }

--- a/src/components/pages/home/MainView/useDisplayedHomemodules.js
+++ b/src/components/pages/home/MainView/useDisplayedHomemodules.js
@@ -20,13 +20,16 @@ export const shouldModuleBeDisplayed = algoliaMapping => module => {
 const useDisplayedHomemodules = (history, geolocation) => {
   const [modules, setModules] = useState([])
   const [algoliaMapping, setAlgoliaMapping] = useState({})
-  const [fetchingError, setFetchingError] = useState(false)
+  const [isError, setIsError] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
     const parsedSearch = parse(history.location.search)
+    setIsError(false)
+    setIsLoading(true)
     fetchHomepage({ entryId: parsedSearch ? parsedSearch.entryId : '' })
       .then(setModules)
-      .catch(() => setFetchingError(true))
+      .catch(() => setIsError(true))
   }, [history.location.search])
 
   useEffect(() => {
@@ -48,15 +51,22 @@ const useDisplayedHomemodules = (history, geolocation) => {
           mapping[moduleId] = { nbHits, hits, parsedParameters }
         })
         setAlgoliaMapping(mapping)
+        setIsLoading(false)
       }
 
-      fetchAlgoliaModules()
+      try {
+        fetchAlgoliaModules()
+      } catch (error) {
+        setIsError(true)
+        setIsLoading(false)
+      }
     }
   }, [modules, geolocation])
 
   return {
     displayedModules: modules.filter(shouldModuleBeDisplayed(algoliaMapping)),
-    fetchingError,
+    isError,
+    isLoading,
     algoliaMapping,
   }
 }

--- a/src/components/pages/home/MainView/useDisplayedHomemodules.js
+++ b/src/components/pages/home/MainView/useDisplayedHomemodules.js
@@ -23,8 +23,8 @@ const useDisplayedHomemodules = (history, geolocation) => {
   const [fetchingError, setFetchingError] = useState(false)
 
   useEffect(() => {
-    const { entryId } = parse(history.location.search)
-    fetchHomepage({ entryId })
+    const parsedSearch = parse(history.location.search)
+    fetchHomepage({ entryId: parsedSearch ? parsedSearch.entryId : '' })
       .then(setModules)
       .catch(() => setFetchingError(true))
   }, [history.location.search])

--- a/src/components/pages/home/MainView/useDisplayedHomemodules.js
+++ b/src/components/pages/home/MainView/useDisplayedHomemodules.js
@@ -1,0 +1,64 @@
+import { parse } from 'query-string'
+import { useEffect, useState } from 'react'
+
+import { fetchAlgolia } from '../../../../vendor/algolia/algolia'
+import { fetchHomepage } from '../../../../vendor/contentful/contentful'
+import { parseAlgoliaParameters } from './domain/parseAlgoliaParameters'
+import Offers from './domain/ValueObjects/Offers'
+import OffersWithCover from './domain/ValueObjects/OffersWithCover'
+
+const shouldModuleBeDisplayed = algoliaMapping => module => {
+  if (module instanceof Offers || module instanceof OffersWithCover) {
+    const { hits = [], nbHits = 0 } = algoliaMapping[module.moduleId] || {}
+    const atLeastOneHit = hits.length > 0
+    const minOffersHasBeenReached = nbHits >= module.display.minOffers
+    return atLeastOneHit && minOffersHasBeenReached
+  }
+  return true
+}
+
+const useDisplayedHomemodules = (history, geolocation) => {
+  const [modules, setModules] = useState([])
+  const [algoliaMapping, setAlgoliaMapping] = useState({})
+  const [fetchingError, setFetchingError] = useState(false)
+
+  useEffect(() => {
+    const { entryId } = parse(history.location.search)
+    fetchHomepage({ entryId })
+      .then(setModules)
+      .catch(() => setFetchingError(true))
+  }, [history.location.search])
+
+  useEffect(() => {
+    if (modules.length) {
+      const fetchAlgoliaModules = async () =>
+        await Promise.all(
+          modules
+            .filter(module => module instanceof Offers || module instanceof OffersWithCover)
+            .map(async ({ algolia: parameters, moduleId }) => {
+              const parsedParameters = parseAlgoliaParameters({ geolocation, parameters })
+              if (!parsedParameters) return
+
+              const response = await fetchAlgolia(parsedParameters)
+              return { moduleId, parsedParameters, ...response }
+            })
+        )
+
+      fetchAlgoliaModules().then(algoliaModules => {
+        const mapping = {}
+        algoliaModules.filter(Boolean).forEach(({ moduleId, nbHits, hits, parsedParameters }) => {
+          mapping[moduleId] = { nbHits, hits, parsedParameters }
+        })
+        setAlgoliaMapping(mapping)
+      })
+    }
+  }, [modules, geolocation])
+
+  return {
+    displayedModules: modules.filter(shouldModuleBeDisplayed(algoliaMapping)),
+    fetchingError,
+    algoliaMapping,
+  }
+}
+
+export default useDisplayedHomemodules

--- a/src/components/pages/home/MainView/useDisplayedHomemodules.js
+++ b/src/components/pages/home/MainView/useDisplayedHomemodules.js
@@ -31,8 +31,8 @@ const useDisplayedHomemodules = (history, geolocation) => {
 
   useEffect(() => {
     if (modules.length) {
-      const fetchAlgoliaModules = async () =>
-        await Promise.all(
+      const fetchAlgoliaModules = async () => {
+        const algoliaModules = await Promise.all(
           modules
             .filter(module => module instanceof Offers || module instanceof OffersWithCover)
             .map(async ({ algolia: parameters, moduleId }) => {
@@ -43,14 +43,14 @@ const useDisplayedHomemodules = (history, geolocation) => {
               return { moduleId, parsedParameters, ...response }
             })
         )
-
-      fetchAlgoliaModules().then(algoliaModules => {
         const mapping = {}
         algoliaModules.filter(Boolean).forEach(({ moduleId, nbHits, hits, parsedParameters }) => {
           mapping[moduleId] = { nbHits, hits, parsedParameters }
         })
         setAlgoliaMapping(mapping)
-      })
+      }
+
+      fetchAlgoliaModules()
     }
   }, [modules, geolocation])
 

--- a/src/components/pages/home/MainView/useDisplayedHomemodules.js
+++ b/src/components/pages/home/MainView/useDisplayedHomemodules.js
@@ -7,7 +7,7 @@ import { parseAlgoliaParameters } from './domain/parseAlgoliaParameters'
 import Offers from './domain/ValueObjects/Offers'
 import OffersWithCover from './domain/ValueObjects/OffersWithCover'
 
-const shouldModuleBeDisplayed = algoliaMapping => module => {
+export const shouldModuleBeDisplayed = algoliaMapping => module => {
   if (module instanceof Offers || module instanceof OffersWithCover) {
     const { hits = [], nbHits = 0 } = algoliaMapping[module.moduleId] || {}
     const atLeastOneHit = hits.length > 0

--- a/src/components/pages/home/MainView/useDisplayedHomemodules.spec.js
+++ b/src/components/pages/home/MainView/useDisplayedHomemodules.spec.js
@@ -1,0 +1,98 @@
+import Offers from './domain/ValueObjects/Offers'
+import { PANE_LAYOUT } from './domain/layout'
+import { shouldModuleBeDisplayed } from './useDisplayedHomemodules'
+import BusinessPane from './domain/ValueObjects/BusinessPane'
+import ExclusivityPane from './domain/ValueObjects/ExclusivityPane'
+
+const algolia = {
+  aroundRadius: null,
+  beginningDatetime: null,
+  categories: ['Cinéma', 'Cours, ateliers', 'Livres'],
+  endingDatetime: null,
+  hitsPerPage: 3,
+  isDigital: false,
+  isDuo: true,
+  isFree: false,
+  isEvent: true,
+  isGeolocated: false,
+  isThing: true,
+  newestOnly: true,
+  priceMax: 10,
+  priceMin: 1,
+  title: 'Mes paramètres Algolia',
+}
+let display = {
+  activeOn: '2020-07-01T00:00+02:00',
+  activeUntil: '2020-07-30T00:00+02:00',
+  layout: PANE_LAYOUT['ONE-ITEM-MEDIUM'],
+  minOffers: 1,
+  title: 'Les offres près de chez toi!',
+}
+const offerOne = {
+  objectID: 'NE',
+  offer: {
+    dates: [],
+    id: 'NE',
+    label: 'Cinéma',
+    name: "Dansons jusqu'en 2030",
+    priceMax: 33,
+    priceMin: 33,
+    thumbUrl: 'http://localhost/storage/thumbs/mediations/KQ',
+  },
+  venue: {
+    name: 'Le Sous-sol',
+  },
+}
+const offerTwo = {
+  objectID: 'AE',
+  offer: {
+    dates: [],
+    id: 'AE',
+    label: 'Presse',
+    name: 'Naruto',
+    priceMax: 1,
+    priceMin: 12,
+    thumbUrl: 'http://localhost/storage/thumbs/mediations/PP',
+  },
+  venue: {
+    name: 'Librairie Kléber',
+  },
+}
+
+describe('shouldModuleBeDisplayed', () => {
+  it('should display module Business', () => {
+    const algoliaMapping = {}
+    const module = new BusinessPane({ title: 'Title' })
+    expect(shouldModuleBeDisplayed(algoliaMapping)(module)).toBeTruthy()
+  })
+  it('should display module Exclu', () => {
+    const algoliaMapping = {}
+    const module = new ExclusivityPane({ alt: 'alt', image: 'image', offerId: 'offerId' })
+    expect(shouldModuleBeDisplayed(algoliaMapping)(module)).toBeTruthy()
+  })
+  it('should display module Offer if enough offers', () => {
+    const algoliaMapping = {
+      moduleId: { hits: [offerOne, offerTwo], nbHits: 2, parsedParameters: {} },
+    }
+    display.minOffers = 2
+    const module = new Offers({ algolia, display, moduleId: 'moduleId' })
+    expect(shouldModuleBeDisplayed(algoliaMapping)(module)).toBeTruthy()
+  })
+
+  it('should not display Offer when no hits', () => {
+    const algoliaMapping = {
+      moduleId: { hits: [], nbHits: 0, parsedParameters: {} },
+    }
+    const module = new Offers({ algolia, display, moduleId: 'moduleId' })
+    expect(shouldModuleBeDisplayed(algoliaMapping)(module)).toBeFalsy()
+  })
+
+  it('should not display Offer when not enough offers to be displayed', () => {
+    const algoliaMapping = {
+      moduleId: { hits: [offerOne, offerTwo], nbHits: 2, parsedParameters: {} },
+    }
+    display.minOffers = 3
+    const module = new Offers({ algolia, display, moduleId: 'moduleId' })
+    expect(shouldModuleBeDisplayed(algoliaMapping)(module)).toBeFalsy()
+  })
+})

--- a/src/components/pages/home/Profile/Header/Header.jsx
+++ b/src/components/pages/home/Profile/Header/Header.jsx
@@ -17,9 +17,7 @@ const Header = ({ user }) => {
         className="ph-back-link"
         to="/accueil"
       >
-        <Icon
-          svg="ico-arrow-previous"
-        />
+        <Icon svg="ico-arrow-previous" />
       </Link>
       <div className="ph-pseudo">
         {`${publicName}`}
@@ -35,7 +33,7 @@ const Header = ({ user }) => {
 }
 
 Header.propTypes = {
-  user: PropTypes.instanceOf(User).isRequired,
+  user: PropTypes.shape(User).isRequired,
 }
 
 export default Header

--- a/src/components/pages/home/Profile/MainView/MainView.jsx
+++ b/src/components/pages/home/Profile/MainView/MainView.jsx
@@ -28,7 +28,7 @@ const MainView = ({ user, historyPush }) => (
 
 MainView.propTypes = {
   historyPush: PropTypes.func.isRequired,
-  user: PropTypes.instanceOf(User).isRequired,
+  user: PropTypes.shape(User).isRequired,
 }
 
 export default MainView

--- a/src/components/pages/home/Profile/PersonalInformations/PersonalInformations.jsx
+++ b/src/components/pages/home/Profile/PersonalInformations/PersonalInformations.jsx
@@ -127,7 +127,7 @@ PersonalInformations.propTypes = {
   pathToProfile: PropTypes.string.isRequired,
   triggerSuccessSnackbar: PropTypes.func.isRequired,
   updateCurrentUser: PropTypes.func.isRequired,
-  user: PropTypes.instanceOf(User).isRequired,
+  user: PropTypes.shape(User).isRequired,
 }
 
 export default PersonalInformations

--- a/src/components/pages/home/Profile/RemainingCredit/RemainingCredit.jsx
+++ b/src/components/pages/home/Profile/RemainingCredit/RemainingCredit.jsx
@@ -88,7 +88,7 @@ class RemainingCredit extends PureComponent {
 }
 
 RemainingCredit.propTypes = {
-  user: PropTypes.instanceOf(User).isRequired,
+  user: PropTypes.shape(User).isRequired,
 }
 
 export default RemainingCredit

--- a/src/components/pages/home/__specs__/Home.spec.jsx
+++ b/src/components/pages/home/__specs__/Home.spec.jsx
@@ -151,6 +151,8 @@ describe('src | components | home', () => {
       await flushPromises()
       wrapper.update()
     })
+
+    wrapper.setProps({})
     const moduleName = wrapper.find('Module').find({ children: 'Mon module' })
     expect(moduleName).toHaveLength(1)
   })

--- a/src/components/pages/profile/Header/Header.jsx
+++ b/src/components/pages/profile/Header/Header.jsx
@@ -25,7 +25,7 @@ const Header = ({ user }) => {
 }
 
 Header.propTypes = {
-  user: PropTypes.instanceOf(User).isRequired,
+  user: PropTypes.shape(User).isRequired,
 }
 
 export default Header

--- a/src/components/pages/profile/MainView/MainView.jsx
+++ b/src/components/pages/profile/MainView/MainView.jsx
@@ -28,7 +28,7 @@ const MainView = ({ user, historyPush }) => (
 
 MainView.propTypes = {
   historyPush: PropTypes.func.isRequired,
-  user: PropTypes.instanceOf(User).isRequired,
+  user: PropTypes.shape(User).isRequired,
 }
 
 export default MainView

--- a/src/components/pages/profile/PersonalInformations/PersonalInformations.jsx
+++ b/src/components/pages/profile/PersonalInformations/PersonalInformations.jsx
@@ -127,7 +127,7 @@ PersonalInformations.propTypes = {
   pathToProfile: PropTypes.string.isRequired,
   triggerSuccessSnackbar: PropTypes.func.isRequired,
   updateCurrentUser: PropTypes.func.isRequired,
-  user: PropTypes.instanceOf(User).isRequired,
+  user: PropTypes.shape(User).isRequired,
 }
 
 export default PersonalInformations

--- a/src/components/pages/profile/Profile.jsx
+++ b/src/components/pages/profile/Profile.jsx
@@ -71,7 +71,7 @@ const Profile = ({ history, match, user }) => {
 Profile.propTypes = {
   history: PropTypes.shape().isRequired,
   match: PropTypes.shape().isRequired,
-  user: PropTypes.instanceOf(User).isRequired,
+  user: PropTypes.shape(User).isRequired,
 }
 
 export default Profile

--- a/src/components/pages/profile/RemainingCredit/RemainingCredit.jsx
+++ b/src/components/pages/profile/RemainingCredit/RemainingCredit.jsx
@@ -88,7 +88,7 @@ class RemainingCredit extends PureComponent {
 }
 
 RemainingCredit.propTypes = {
-  user: PropTypes.instanceOf(User).isRequired,
+  user: PropTypes.shape(User).isRequired,
 }
 
 export default RemainingCredit

--- a/src/vendor/contentful/contentful.js
+++ b/src/vendor/contentful/contentful.js
@@ -14,7 +14,13 @@ import ExclusivityPane from '../../components/pages/home/MainView/domain/ValueOb
 const DEPTH_LEVEL = 2
 
 const matchesContentType = (module, contentType) => {
-  const { sys: { contentType: { sys: { id } } } } = module
+  const {
+    sys: {
+      contentType: {
+        sys: { id },
+      },
+    },
+  } = module
   return id === contentType
 }
 
@@ -38,7 +44,8 @@ export const fetchHomepage = ({ entryId = null } = {}) => {
 }
 
 const _fetchByEntry = ({ client, entryId }) => {
-  return client.getEntry(entryId, { include: DEPTH_LEVEL })
+  return client
+    .getEntry(entryId, { include: DEPTH_LEVEL })
     .then(entry => {
       return _process(entry)
     })
@@ -48,7 +55,8 @@ const _fetchByEntry = ({ client, entryId }) => {
 }
 
 const _fetchLastEntry = ({ client }) => {
-  return client.getEntries({ content_type: CONTENT_TYPES.HOMEPAGE, include: DEPTH_LEVEL })
+  return client
+    .getEntries({ content_type: CONTENT_TYPES.HOMEPAGE, include: DEPTH_LEVEL })
     .then(data => {
       const { items } = data
       const lastPublishedHomepage = items[0]
@@ -60,52 +68,60 @@ const _fetchLastEntry = ({ client }) => {
 }
 
 const _process = homepage => {
-  const { fields: { modules } } = homepage
+  const {
+    fields: { modules },
+  } = homepage
 
-  return modules.map(module => {
-    const { fields = {} } = module
+  return modules
+    .map(module => {
+      const { fields = {} } = module
 
-    if (hasAtLeastOneField(fields)) {
-      if (matchesContentType(module, CONTENT_TYPES.ALGOLIA)) {
-        const algoliaParameters = CONTENT_FIELDS.ALGOLIA in fields ? fields[CONTENT_FIELDS.ALGOLIA].fields : {}
-        const displayParameters = CONTENT_FIELDS.DISPLAY in fields ? fields[CONTENT_FIELDS.DISPLAY].fields : {}
+      if (hasAtLeastOneField(fields)) {
+        if (matchesContentType(module, CONTENT_TYPES.ALGOLIA)) {
+          const algoliaParameters =
+            CONTENT_FIELDS.ALGOLIA in fields ? fields[CONTENT_FIELDS.ALGOLIA].fields : {}
+          const displayParameters =
+            CONTENT_FIELDS.DISPLAY in fields ? fields[CONTENT_FIELDS.DISPLAY].fields : {}
 
-        if (hasAtLeastOneField(algoliaParameters)) {
-          if (CONTENT_FIELDS.COVER in fields) {
-            const cover = fields[CONTENT_FIELDS.COVER]
+          if (hasAtLeastOneField(algoliaParameters)) {
+            const moduleId = module.sys.id
+            if (CONTENT_FIELDS.COVER in fields) {
+              const cover = fields[CONTENT_FIELDS.COVER]
 
-            if (hasAtLeastOneField(cover)) {
-              return new OffersWithCover({
+              if (hasAtLeastOneField(cover)) {
+                return new OffersWithCover({
+                  algolia: algoliaParameters,
+                  cover: buildImageUrl(cover.fields),
+                  display: displayParameters,
+                  moduleId,
+                })
+              }
+            } else {
+              return new Offers({
                 algolia: algoliaParameters,
-                cover: buildImageUrl(cover.fields),
                 display: displayParameters,
+                moduleId,
               })
             }
-          } else {
-            return new Offers({
-              algolia: algoliaParameters,
-              display: displayParameters,
+          }
+        } else {
+          if (matchesContentType(module, CONTENT_TYPES.EXCLUSIVITY)) {
+            return new ExclusivityPane({
+              alt: fields[CONTENT_FIELDS.ALT],
+              image: buildImageUrl(fields),
+              offerId: fields[CONTENT_FIELDS.OFFER_ID],
             })
           }
-        }
-      } else {
-        if (matchesContentType(module, CONTENT_TYPES.EXCLUSIVITY)) {
-          return new ExclusivityPane({
-            alt: fields[CONTENT_FIELDS.ALT],
+          return new BusinessPane({
+            firstLine: fields[CONTENT_FIELDS.FIRST_LINE],
             image: buildImageUrl(fields),
-            offerId: fields[CONTENT_FIELDS.OFFER_ID],
+            secondLine: fields[CONTENT_FIELDS.SECOND_LINE],
+            url: fields[CONTENT_FIELDS.URL],
           })
         }
-        return new BusinessPane({
-          firstLine: fields[CONTENT_FIELDS.FIRST_LINE],
-          image: buildImageUrl(fields),
-          secondLine: fields[CONTENT_FIELDS.SECOND_LINE],
-          url: fields[CONTENT_FIELDS.URL],
-        })
       }
-    }
-  },
-  ).filter(module => module !== undefined)
+    })
+    .filter(module => module !== undefined)
 }
 
 const buildImageUrl = fields => {


### PR DESCRIPTION
Lien du ticket Jira : https://passculture.atlassian.net/browse/PC-5739

Problèmes:
 - `trackAllModulesSeen` était déclenché dès le chargement de la page, pas quand l'utilisateur scrollait tout en bas de la page.
 - `trackAllModulesSeen` était déclenché avec tous les modules, même ceux qui n'étaient pas forcément affichés.

Résolution:
 - On affiche un Loader tant qu'on a pas tous les modules + toutes les réponses à algolia.
  => ça permet d'éviter le flicker lors du chargement de la page.
 - Quand on affiche la page avec les modules, on check au premier render si on doit trigger `trackAllModulesSeen`.
 - sinon on check `trackAllModulesSeen` lors du scroll.

J'en ai profité pour:
 - transformer `Home` et `Module` en composant fonctionnels.

Tracking:
 - que ce soit pour `AllModulesSeen` ou `AllTilesSeen`, on utilise des références, par exemple `haveAlreadySeenAllTiles` pour ne déclencher les évènements qu'une seule fois