### PR TITLE
(PC-6469) Fix de la recherche des offres ET des analytics liés aux noms de modules

### DIFF
--- a/src/components/layout/Booking/Booking.jsx
+++ b/src/components/layout/Booking/Booking.jsx
@@ -52,7 +52,10 @@ class Booking extends PureComponent {
       handleSubmit(payload, this.handleRequestFail, this.handleRequestSuccess)
     )
     if (history.location.pathname.includes('accueil'))
-      trackBookOfferClickFromHomepage(history.location.moduleName, offer.id)
+      trackBookOfferClickFromHomepage(
+        history.location.state && history.location.state.moduleName,
+        offer.id
+      )
   }
 
   handleRequestSuccess = (state, action) => {
@@ -72,7 +75,10 @@ class Booking extends PureComponent {
     }
     trackBookingSuccess()
     if (history.location.pathname.includes('accueil'))
-      trackBookOfferSuccessFromHomepage(history.location.moduleName, offer.id)
+      trackBookOfferSuccessFromHomepage(
+        history.location.state && history.location.state.moduleName,
+        offer.id
+      )
 
     this.setState(nextState)
     getCurrentUserInformation()

--- a/src/components/layout/Booking/__specs__/Booking.spec.jsx
+++ b/src/components/layout/Booking/__specs__/Booking.spec.jsx
@@ -1,20 +1,18 @@
 import { mount } from 'enzyme'
+import { createMemoryHistory } from 'history'
 import React from 'react'
 
 import Booking from '../Booking'
 
 describe('src | components | layout | Booking | Booking', () => {
   let props
-  let push
-  let replace
-  let handleSubmit
-  let trackBookingSuccess
 
   beforeEach(() => {
-    push = jest.fn()
-    replace = jest.fn()
-    handleSubmit = jest.fn()
-    trackBookingSuccess = jest.fn()
+    const history = createMemoryHistory()
+    history.push({
+      pathname: 'offre/details/AAA',
+      state: { moduleName: 'Nom du module' },
+    })
     props = {
       bookables: [],
       booking: {
@@ -22,15 +20,8 @@ describe('src | components | layout | Booking | Booking', () => {
           price: 10,
         },
       },
-      handleSubmit,
-      history: {
-        push,
-        replace,
-        location: {
-          pathname: 'offre/details/AAA',
-          moduleName: 'Nom du module',
-        },
-      },
+      handleSubmit: jest.fn(),
+      history,
       isCancelled: false,
       isEvent: false,
       location: {
@@ -52,7 +43,7 @@ describe('src | components | layout | Booking | Booking', () => {
         },
         id: 'AAA',
       },
-      trackBookingSuccess,
+      trackBookingSuccess: jest.fn(),
       trackBookOfferClickFromHomepage: jest.fn(),
       trackBookOfferSuccessFromHomepage: jest.fn(),
       getCurrentUserInformation: jest.fn(),
@@ -151,7 +142,7 @@ describe('src | components | layout | Booking | Booking', () => {
       expect(mockTrackBookOfferSuccess).not.toHaveBeenCalled()
     })
     it('should call tracking offer when history location contains accueil', () => {
-      props.history.location.pathname = 'accueil/details/AE'
+      props.history.push({ pathname: 'accueil/details/AE', state: { moduleName: 'Nom du module' } })
       const mockTrackBookOffer = jest
         .spyOn(props, 'trackBookOfferClickFromHomepage')
         .mockImplementation(jest.fn())

--- a/src/components/layout/Verso/VersoControls/Favorite/Favorite.jsx
+++ b/src/components/layout/Verso/VersoControls/Favorite/Favorite.jsx
@@ -32,7 +32,10 @@ class Favorite extends PureComponent {
   handleFavorite = (offerId, mediationId, isFavorite) => () => {
     const { handleFavorite, history, trackAddToFavoritesFromHome } = this.props
     if (!isFavorite && history.location.pathname.includes('accueil')) {
-      trackAddToFavoritesFromHome(history.location.moduleName, offerId)
+      trackAddToFavoritesFromHome(
+        history.location.state && history.location.state.moduleName,
+        offerId
+      )
     }
 
     this.setState(
@@ -70,8 +73,10 @@ Favorite.propTypes = {
   handleFavorite: PropTypes.func.isRequired,
   history: PropTypes.shape({
     location: PropTypes.shape({
-      moduleName: PropTypes.string.isRequired,
       pathname: PropTypes.string.isRequired,
+      state: PropTypes.shape({
+        moduleName: PropTypes.string.isRequired,
+      }),
     }),
   }).isRequired,
   isFavorite: PropTypes.bool,

--- a/src/components/layout/Verso/VersoControls/Favorite/__specs__/Favorite.spec.jsx
+++ b/src/components/layout/Verso/VersoControls/Favorite/__specs__/Favorite.spec.jsx
@@ -1,4 +1,5 @@
 import { shallow } from 'enzyme'
+import { createMemoryHistory } from 'history'
 import React from 'react'
 
 import Icon from '../../../../../layout/Icon/Icon'
@@ -8,17 +9,17 @@ describe('src | components | Favorite', () => {
   let props
 
   beforeEach(() => {
+    const history = createMemoryHistory()
+    history.push({
+      pathname: 'accueil/details/AE',
+      state: { moduleName: 'Nom du module' },
+    })
     props = {
       handleFavorite: jest.fn(),
+      history,
       isFavorite: true,
       loadFavorites: jest.fn(),
       offerId: 'AE',
-      history: {
-        location: {
-          pathname: 'accueil/details/AE',
-          moduleName: 'Nom du module',
-        },
-      },
       trackAddToFavoritesFromHome: jest.fn(),
     }
   })
@@ -61,7 +62,10 @@ describe('src | components | Favorite', () => {
     it('should not call AddToFavoritesFromHome on offer page', () => {
       // given
       props.isFavorite = false
-      props.history.location.pathname = 'offre/details/AE'
+      props.history.push({
+        pathname: 'offre/details/AE',
+        state: { moduleName: 'Nom du module' },
+      })
       const wrapper = shallow(<Favorite {...props} />)
 
       const mockTrackAddToFavorite = jest

--- a/src/components/layout/Verso/VersoControls/booking/BookingAction/BookingActionContainer.js
+++ b/src/components/layout/Verso/VersoControls/booking/BookingAction/BookingActionContainer.js
@@ -10,7 +10,7 @@ import { selectPastEventBookingByOfferId } from '../../../../../../redux/selecto
 
 export const mapStateToProps = (state, ownProps) => {
   const { location, match } = ownProps
-  const { pathname, search, moduleName } = location
+  const { pathname, search, state: locationState } = location
 
   const bookingUrl = `${pathname}/reservation${search}`
 
@@ -26,7 +26,7 @@ export const mapStateToProps = (state, ownProps) => {
     bookingUrl,
     offerCannotBeBooked,
     priceRange,
-    moduleName,
+    moduleName: locationState && locationState.moduleName,
   }
 }
 

--- a/src/components/layout/Verso/VersoControls/booking/BookingAction/__specs__/BookingAction.spec.jsx
+++ b/src/components/layout/Verso/VersoControls/booking/BookingAction/__specs__/BookingAction.spec.jsx
@@ -18,9 +18,8 @@ describe('components | BookingAction', () => {
   beforeEach(() => {
     props = {
       bookingUrl: 'http://booking-layout.com',
-      history: {
-        push: jest.fn(),
-      },
+      history: createMemoryHistory(),
+      moduleName: 'Nom du module',
       offerCannotBeBooked: false,
       priceRange: [10, 30],
     }
@@ -69,9 +68,7 @@ describe('components | BookingAction', () => {
       selectOfferByRouterMatch.mockReturnValueOnce({
         isBookable: true,
       })
-
-      const mockHistory = createMemoryHistory()
-      mockHistory.push('/decouverte?param=value')
+      props.history.push('/decouverte?param=value', { moduleName: 'Nom du module' })
       const mockStore = getStubStore({
         data: (
           state = {
@@ -85,7 +82,7 @@ describe('components | BookingAction', () => {
 
       const wrapper = mount(
         <Provider store={mockStore}>
-          <Router history={mockHistory}>
+          <Router history={props.history}>
             <BookingActionContainer />
           </Router>
         </Provider>
@@ -95,9 +92,9 @@ describe('components | BookingAction', () => {
       wrapper.find({ children: 'J’y vais !' }).simulate('click')
 
       // then
-      expect(`${mockHistory.location.pathname}${mockHistory.location.search}`).toBe(
-        '/decouverte/reservation?param=value'
-      )
+      expect(props.history.location.pathname).toStrictEqual('/decouverte/reservation')
+      expect(props.history.location.search).toStrictEqual('?param=value')
+      expect(props.history.location.state).toStrictEqual({ moduleName: 'Nom du module' })
     })
   })
 })

--- a/src/components/pages/home/MainView/Module/OfferTile/OfferTile.jsx
+++ b/src/components/pages/home/MainView/Module/OfferTile/OfferTile.jsx
@@ -28,7 +28,7 @@ const OfferTile = ({ historyPush, hit, isSwitching, layout, trackConsultOffer, m
       trackConsultOffer(offer.id)
       historyPush({
         pathname: `/accueil/details/${offer.id}`,
-        moduleName,
+        state: { moduleName },
       })
     }
     event.preventDefault()

--- a/src/components/pages/home/MainView/Module/OfferTile/__specs__/OfferTile.spec.jsx
+++ b/src/components/pages/home/MainView/Module/OfferTile/__specs__/OfferTile.spec.jsx
@@ -1,20 +1,23 @@
 import { mount } from 'enzyme'
 import React from 'react'
-import { MemoryRouter } from 'react-router'
+import { Router } from 'react-router'
 import OfferTile, { noOp } from '../OfferTile'
 import { Link } from 'react-router-dom'
 import { DEFAULT_THUMB_URL } from '../../../../../../../utils/thumb'
 import { formatSearchResultDate } from '../../../../../../../utils/date/date'
+import { createMemoryHistory } from 'history'
 
 jest.mock('../../../../../../../utils/date/date', () => ({
   formatSearchResultDate: jest.fn(),
 }))
 describe('src | components | OfferTile', () => {
   let props
+  let history
 
   beforeEach(() => {
+    history = createMemoryHistory()
     props = {
-      historyPush: jest.fn(),
+      historyPush: history.push,
       hit: {
         offer: {
           dates: [],
@@ -29,19 +32,21 @@ describe('src | components | OfferTile', () => {
         venue: {
           departementCode: '54',
           name: 'Librairie kléber',
-          publicName: null
+          publicName: null,
         },
       },
+      moduleName: 'Nom du module',
       isSwitching: false,
+      trackConsultOffer: jest.fn(),
     }
   })
 
   it('should render an offer tile with a link', () => {
     // when
     const wrapper = mount(
-      <MemoryRouter>
+      <Router history={history}>
         <OfferTile {...props} />
-      </MemoryRouter>
+      </Router>
     )
 
     // then
@@ -55,9 +60,9 @@ describe('src | components | OfferTile', () => {
   it('should render an offer tile with an image when provided', () => {
     // when
     const wrapper = mount(
-      <MemoryRouter>
+      <Router history={history}>
         <OfferTile {...props} />
-      </MemoryRouter>
+      </Router>
     )
 
     // then
@@ -73,9 +78,9 @@ describe('src | components | OfferTile', () => {
 
     // when
     const wrapper = mount(
-      <MemoryRouter>
+      <Router history={history}>
         <OfferTile {...props} />
-      </MemoryRouter>
+      </Router>
     )
 
     // then
@@ -87,9 +92,9 @@ describe('src | components | OfferTile', () => {
   it('should render an offer tile with venue name when public name is not provided', () => {
     // when
     const wrapper = mount(
-      <MemoryRouter>
+      <Router history={history}>
         <OfferTile {...props} />
-      </MemoryRouter>
+      </Router>
     )
 
     // then
@@ -100,9 +105,9 @@ describe('src | components | OfferTile', () => {
   it('should render an offer tile with the price', () => {
     // when
     const wrapper = mount(
-      <MemoryRouter>
+      <Router history={history}>
         <OfferTile {...props} />
-      </MemoryRouter>
+      </Router>
     )
 
     // then
@@ -119,9 +124,9 @@ describe('src | components | OfferTile', () => {
 
     // when
     const wrapper = mount(
-      <MemoryRouter>
+      <Router history={history}>
         <OfferTile {...props} />
-      </MemoryRouter>
+      </Router>
     )
 
     // then
@@ -132,9 +137,9 @@ describe('src | components | OfferTile', () => {
   it('should render an offer tile with the offer name', () => {
     // when
     const wrapper = mount(
-      <MemoryRouter>
+      <Router history={history}>
         <OfferTile {...props} />
-      </MemoryRouter>
+      </Router>
     )
 
     // then
@@ -148,13 +153,33 @@ describe('src | components | OfferTile', () => {
 
     // when
     const wrapper = mount(
-      <MemoryRouter>
+      <Router history={history}>
         <OfferTile {...props} />
-      </MemoryRouter>
+      </Router>
     )
 
     // then
     const venue = wrapper.find({ children: 'Un autre nom pour la librairie' })
     expect(venue).toHaveLength(1)
+  })
+
+  it('should go to offer when clicking on the link', () => {
+    // given
+    props.hit.venue.publicName = 'Un autre nom pour la librairie'
+
+    // when
+    const wrapper = mount(
+      <Router history={history}>
+        <OfferTile {...props} />
+      </Router>
+    )
+    const offerLink = wrapper.find(Link)
+    offerLink.simulate('click')
+
+    // then
+    expect(history.location.pathname).toStrictEqual(`/accueil/details/AE`)
+    expect(history.location.search).toStrictEqual('')
+    expect(history.location.state).toStrictEqual({ moduleName: 'Nom du module' })
+    expect(props.trackConsultOffer).toHaveBeenCalledWith('AE')
   })
 })

--- a/src/components/pages/search/Home/Home.jsx
+++ b/src/components/pages/search/Home/Home.jsx
@@ -38,7 +38,7 @@ export class Home extends PureComponent {
       `&longitude=${searchAround.place ? placeGeolocation.longitude : userGeolocation.longitude}` +
       `${searchAround.place ? `&place=${long}` : ''}`
 
-    history.push('/recherche/resultats', { search })
+    history.push(`/recherche/resultats${search}`)
   }
 
   handleResetButtonClick = () => {

--- a/src/components/pages/search/Home/__specs__/Home.spec.jsx
+++ b/src/components/pages/search/Home/__specs__/Home.spec.jsx
@@ -1,4 +1,4 @@
-import { mount, shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import { createMemoryHistory } from 'history'
 import React from 'react'
 import { Router } from 'react-router-dom'
@@ -6,9 +6,11 @@ import { CriterionItem } from '../CriterionItem/CriterionItem'
 import { Home } from '../Home'
 
 describe('components | Home', () => {
+  let history
   let props
 
   beforeEach(() => {
+    history = createMemoryHistory()
     props = {
       categoryCriterion: {
         filters: [],
@@ -42,9 +44,6 @@ describe('components | Home', () => {
         latitude: 40,
         longitude: 41,
       },
-      history: {
-        push: jest.fn(),
-      },
       sortCriterion: {
         index: '',
         icon: 'ico-relevance',
@@ -54,15 +53,10 @@ describe('components | Home', () => {
     }
   })
 
-  it('should clear text input when clicking on reset cross', async () => {
+  it('should clear text input when clicking on reset cross', () => {
     // given
-    const history = createMemoryHistory()
     history.push('/recherche')
-    const wrapper = await mount(
-      <Router history={history}>
-        <Home {...props} />
-      </Router>
-    )
+    const wrapper = mountHomeInRouter(props, history)
     const form = wrapper.find('form')
     const input = form.find('input').first()
     input.simulate('change', {
@@ -95,11 +89,7 @@ describe('components | Home', () => {
     }
     props.categoryCriterion.facetFilter = 'CINEMA'
     props.sortCriterion.index = '_by_price'
-    const wrapper = mount(
-      <Router history={createMemoryHistory()}>
-        <Home {...props} />
-      </Router>
-    )
+    const wrapper = mountHomeInRouter(props, history)
     const form = wrapper.find('form')
     const input = form.find('input')
 
@@ -115,10 +105,10 @@ describe('components | Home', () => {
     })
 
     // then
-    expect(props.history.push).toHaveBeenCalledWith('/recherche/resultats', {
-      search:
-        '?mots-cles=search keyword&autour-de=non&tri=_by_price&categories=CINEMA&latitude=40&longitude=41',
-    })
+    expect(history.location.pathname).toStrictEqual('/recherche/resultats')
+    expect(history.location.search).toStrictEqual(
+      '?mots-cles=search keyword&autour-de=non&tri=_by_price&categories=CINEMA&latitude=40&longitude=41'
+    )
   })
 
   it('should redirect to result page when search is around user', () => {
@@ -128,11 +118,7 @@ describe('components | Home', () => {
       place: false,
       user: true,
     }
-    const wrapper = mount(
-      <Router history={createMemoryHistory()}>
-        <Home {...props} />
-      </Router>
-    )
+    const wrapper = mountHomeInRouter(props, history)
     const form = wrapper.find('form')
     const input = form.find('input')
 
@@ -148,9 +134,10 @@ describe('components | Home', () => {
     })
 
     // then
-    expect(props.history.push).toHaveBeenCalledWith('/recherche/resultats', {
-      search: '?mots-cles=search keyword&autour-de=oui&tri=&categories=&latitude=40&longitude=41',
-    })
+    expect(history.location.pathname).toStrictEqual('/recherche/resultats')
+    expect(history.location.search).toStrictEqual(
+      '?mots-cles=search keyword&autour-de=oui&tri=&categories=&latitude=40&longitude=41'
+    )
   })
 
   it('should redirect to result page when search is around place', () => {
@@ -160,11 +147,7 @@ describe('components | Home', () => {
       place: true,
       user: false,
     }
-    const wrapper = mount(
-      <Router history={createMemoryHistory()}>
-        <Home {...props} />
-      </Router>
-    )
+    const wrapper = mountHomeInRouter(props, history)
     const form = wrapper.find('form')
     const input = form.find('input')
 
@@ -180,15 +163,15 @@ describe('components | Home', () => {
     })
 
     // then
-    expect(props.history.push).toHaveBeenCalledWith('/recherche/resultats', {
-      search:
-        "?mots-cles=search keyword&autour-de=oui&tri=&categories=&latitude=59.2&longitude=4.3&place=34 avenue de l'opéra, Paris",
-    })
+    expect(history.location.pathname).toStrictEqual('/recherche/resultats')
+    expect(history.location.search).toStrictEqual(
+      "?mots-cles=search keyword&autour-de=oui&tri=&categories=&latitude=59.2&longitude=4.3&place=34 avenue de l'opéra, Paris"
+    )
   })
 
   it('should render a list of CriterionItem with the right props', () => {
     // when
-    const wrapper = shallow(<Home {...props} />)
+    const wrapper = mountHomeInRouter(props, history)
 
     // then
     const criterionItems = wrapper.find(CriterionItem)
@@ -207,3 +190,14 @@ describe('components | Home', () => {
     expect(criterionItems.at(2).prop('selectedFilter')).toBe('Pertinence')
   })
 })
+
+function mountHomeInRouter(props, history) {
+  return mount(
+    <Router history={history}>
+      <Home
+        {...props}
+        history={history}
+      />
+    </Router>
+  )
+}


### PR DESCRIPTION
**Lien du ticket** : https://passculture.atlassian.net/browse/PC-6469

**Ticket à l'origine des bugs** : https://passculture.atlassian.net/browse/PC-6320

Test unitaires de non-regressions ajoutés / mis à jours : 👍🏻 

Notes sur `react-router`: 

- Ne pas confondre `search`(query params) et `state`(que j'aime à penser comme des query params secrets) de l'objet `history.location`
- Faire attention aux différentes manières d'appeler `history.push()` : 
  - `history.push(entireUrl)` 
  - `history.push(pathname, state)` ==> `state` !== `search`
  - `history.push({ pathname, search, state, etc... })`
 - Ne pas déclarer de nouvelles propriétés sur l'objet `location` (comme par exemple `location.moduleName`). Il y a `location.state` ou `location.search` pour cela, selon si on veut que les valeurs de ces propriétés soient visibles dans l'URL ou pas.