### PR TITLE
[PC-5511] Le filtre par date inclut des offres non disponibles à la date choisie 🐛

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "license-reporter": "^1.2.2",
     "lint-staged": "^10.3.0",
     "mini-css-extract-plugin": "^0.8.0",
+    "mockdate": "^3.0.2",
     "node-sass": "^4.13.1",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^3.0.0",

--- a/src/components/pages/search/Results/ResultsList/Result/__specs__/Result.spec.jsx
+++ b/src/components/pages/search/Results/ResultsList/Result/__specs__/Result.spec.jsx
@@ -1,3 +1,4 @@
+import mockdate from 'mockdate'
 import { shallow } from 'enzyme'
 import React from 'react'
 
@@ -9,6 +10,9 @@ jest.mock('../../../../../../../utils/thumb', () => ({
 
 describe('components | Result', () => {
   let props
+  beforeAll(() => {
+    mockdate.set(new Date(2020, 0, 1))
+  })
 
   beforeEach(() => {
     props = {

--- a/src/components/pages/search/Results/ResultsList/Result/__specs__/Result.spec.jsx
+++ b/src/components/pages/search/Results/ResultsList/Result/__specs__/Result.spec.jsx
@@ -49,7 +49,7 @@ describe('components | Result', () => {
     // then
     const offerName = wrapper.findWhere(node => node.text() === 'Les fleurs du mal').first()
     const offerLabel = wrapper.findWhere(node => node.text() === 'Livre').first()
-    const offerDate = wrapper.findWhere(node => node.text() === 'Dimanche 29 mars 12:27').first()
+    const offerDate = wrapper.findWhere(node => node.text() === 'Dimanche 29 mars 14:27').first()
     const offerPrice = wrapper.findWhere(node => node.text() === 'À partir de 8 €').first()
     const offerDistance = wrapper.findWhere(node => node.text() === '900+ km').first()
     const offerMediation = wrapper.find('img')

--- a/src/utils/date/date.js
+++ b/src/utils/date/date.js
@@ -39,31 +39,35 @@ export const humanizeDate = (date, timezone) =>
   capitalize(moment(date).tz(timezone).format('dddd DD/MM/YYYY à H:mm'))
 
 export const formatSearchResultDate = (departmentCode, allDatesInSeconds = []) => {
-  const nowInSeconds = new Date().valueOf() / 1000
-  const dates = allDatesInSeconds.filter(date => date.valueOf() > nowInSeconds)
+  const dates = allDatesInSeconds
+    .map(seconds => new Date(MILLISECONDS_IN_A_SECOND * seconds))
+    .filter(date => date > new Date())
+    .sort()
 
   if (dates.length === 0) return null
 
-  const timezone = getTimezone(departmentCode)
+  const timeZone = getTimezone(departmentCode)
 
   const numberOfBookableDates = dates.length
-  let firstBookableDate = new Date(dates[0] * MILLISECONDS_IN_A_SECOND)
-  let lastBookableDate = new Date(dates[numberOfBookableDates - 1] * MILLISECONDS_IN_A_SECOND)
+  const firstBookableDate = dates[0]
+  const lastBookableDate = dates[numberOfBookableDates - 1]
 
-  const day = firstBookableDate.toLocaleString(LOCALE_FRANCE, { timezone, day: '2-digit' })
-  const month = firstBookableDate.toLocaleString(LOCALE_FRANCE, { timezone, month: 'long' })
+  const day = firstBookableDate.toLocaleString(LOCALE_FRANCE, { timeZone, day: '2-digit' })
+  const month = firstBookableDate.toLocaleString(LOCALE_FRANCE, { timeZone, month: 'long' })
 
   const bookableDatesAreOnTheSameDay = firstBookableDate.getDate() === lastBookableDate.getDate()
   const onlyOneBookableDate = numberOfBookableDates === 1
   if (bookableDatesAreOnTheSameDay || onlyOneBookableDate) {
-    const hours = firstBookableDate.getHours()
-    const minutes = firstBookableDate.getMinutes()
-    const hoursWithLeadingZero = hours < 10 ? '0' + hours : hours
-    const minutesWithLeadingZero = minutes < 10 ? '0' + minutes : minutes
-    const weekDay = firstBookableDate.toLocaleString(LOCALE_FRANCE, { timezone, weekday: 'long' })
+    const hoursMinutes = firstBookableDate.toLocaleString(LOCALE_FRANCE, {
+      timeZone,
+      hour: '2-digit',
+      minute: '2-digit',
+    })
 
+    const weekDay = firstBookableDate.toLocaleString(LOCALE_FRANCE, { timeZone, weekday: 'long' })
     const capitalizedWeekDay = weekDay.charAt(0).toUpperCase() + weekDay.slice(1)
-    return `${capitalizedWeekDay} ${day} ${month} ${hoursWithLeadingZero}:${minutesWithLeadingZero}`
+
+    return `${capitalizedWeekDay} ${day} ${month} ${hoursMinutes}`
   }
 
   return `À partir du ${day} ${month}`

--- a/src/utils/date/date.js
+++ b/src/utils/date/date.js
@@ -32,19 +32,16 @@ export const formatRecommendationDates = (departementCode, dateRange = []) => {
 }
 
 export const dateStringPlusTimeZone = (dateString, departementCode) => {
-  return moment(dateString)
-    .tz(getTimezone(departementCode))
-    .format('YYYY-MM-DD HH:mm:ss')
+  return moment(dateString).tz(getTimezone(departementCode)).format('YYYY-MM-DD HH:mm:ss')
 }
 
 export const humanizeDate = (date, timezone) =>
-  capitalize(
-    moment(date)
-      .tz(timezone)
-      .format('dddd DD/MM/YYYY à H:mm')
-  )
+  capitalize(moment(date).tz(timezone).format('dddd DD/MM/YYYY à H:mm'))
 
-export const formatSearchResultDate = (departmentCode, dates = []) => {
+export const formatSearchResultDate = (departmentCode, allDatesInSeconds = []) => {
+  const nowInSeconds = new Date().valueOf() / 1000
+  const dates = allDatesInSeconds.filter(date => date.valueOf() > nowInSeconds)
+
   if (dates.length === 0) return null
 
   const timezone = getTimezone(departmentCode)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9026,6 +9026,11 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "^1.2.5"
 
+mockdate@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.2.tgz#a5a7bb5820da617747af424d7a4dcb22c6c03d79"
+  integrity sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==
+
 moment-duration-format-commonjs@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/moment-duration-format-commonjs/-/moment-duration-format-commonjs-1.0.0.tgz#dc5de612e6d6ff41f774d03772a139a363563bc3"


### PR DESCRIPTION
Nous sommes le 28 janvier, 17h:

#### Avant
![image](https://user-images.githubusercontent.com/10118284/106169706-f430f980-618f-11eb-9a63-535f17c22b06.png)

#### Après
![image](https://user-images.githubusercontent.com/10118284/106169690-eda28200-618f-11eb-9413-2807bbb27bea.png)


#### Quand on clique sur l'offre:
![image](https://user-images.githubusercontent.com/10118284/106169910-335f4a80-6190-11eb-8af6-bdeafbbd4c96.png)
