### PR TITLE
(PC-6129) : Fix iOS universal link file installation

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -148,6 +148,7 @@ module.exports = {
             {
               from: `${paths.appAssetLinksDirectory}/apple-app-site-association`,
               to: `${paths.appBuild}/.well-known/apple-app-site-association`,
+              toType: 'file',
             },
           ]),
         ]


### PR DESCRIPTION
Because the file does not have an extention, the `CopyWebpackPlugin`
assumes the destination `to` is a directory.
We need to explicitely declare the `to` destination as being the
actual file name.