### PR TITLE
Webapp use beta.gouv.fr url that is now on GCP

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -2,7 +2,7 @@ ALGOLIA_APPLICATION_ID=testingHXXTDUE7H0
 ALGOLIA_SEARCH_API_KEY=ef6ccdf2d194918b5a3ee22ff5c2d287
 ALGOLIA_INDEX_NAME=TESTING
 ANDROID_APPLICATION_ID=app.passculture.testing.webapp
-API_URL=https://pass-culture-api-dev.osc-fr1.scalingo.io
+API_URL=https://backend.passculture-testing.beta.gouv.fr
 BATCH_IS_ENABLED=true
 BATCH_API_KEY=E355580F9EE34DD49B774F79C532535D
 BATCH_AUTH_KEY=2.fbqGj1rZvtaPIqmbw5tpi/3vmH6Wd6AmzKJ0QX6pjDY=


### PR DESCRIPTION
This reverts commit 9f033b49043f119a7d0a9e866757681d76d84290.