### PR TITLE
(PC-6129) : Add content type for iOS universal links file

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,3 +5,5 @@
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
 /.well-known/*
   Content-Type: application/json
+/.well-known/apple-app-site-association
+  Content-Type: application/pkcs7-mime


### PR DESCRIPTION
Not sure why it seems the file served as "application/json" did not work.