### PR TITLE
(PC-6917) Add minimum in expenses gauges

### DIFF
--- a/src/components/pages/profile/domain/getRemainingCreditForGivenCreditLimit.js
+++ b/src/components/pages/profile/domain/getRemainingCreditForGivenCreditLimit.js
@@ -2,6 +2,6 @@ export const getRemainingCreditForGivenCreditLimit = walletBalance => ({
   current: expenses,
   limit: creditLimit,
 }) => {
-  const absoluteRemainingCredit = creditLimit - expenses
+  const absoluteRemainingCredit = Math.max(creditLimit - expenses, 0)
   return Math.min(walletBalance, absoluteRemainingCredit)
 }


### PR DESCRIPTION
When the expiration date has passed, the expenses limits are set to 0 and the current expenses remain >= 0