### PR TITLE
(PC-7660): Add tabindex and focused state on app title

### DIFF
--- a/src/components/pages/beta-page/BetaPage.jsx
+++ b/src/components/pages/beta-page/BetaPage.jsx
@@ -1,61 +1,74 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 
 import FormFooter from '../../forms/FormFooter'
 import Icon from '../../layout/Icon/Icon'
 
-const BetaPage = ({ trackSignup, isNewBookingLimitsActived, wholeFranceOpening }) => (
-  <div className="beta-page">
-    <Icon
-      alt=""
-      className="bp-logo"
-      svg="circle"
-    />
-    <main className="bp-main">
-      <div className="bp-title">
-        {'Bienvenue dans\n'}
-        {'ton pass Culture'}
-      </div>
-      <div className="bp-content">
-        {'Tu as 18 ans'}
-        {!wholeFranceOpening && (
-          <span>
-            {' et tu vis dans un '}
-            <a
-              href="https://pass.culture.fr/le-dispositif/#dispoexpe"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              {'département éligible'}
-            </a>
-          </span>
-        )}
-        {' ?'}
-      </div>
-      <div className="bp-content">
-        {`Bénéficie de ${isNewBookingLimitsActived ? 300 : 500} € afin de\n`}
-        {'renforcer tes pratiques\n'}
-        {"culturelles et d'en découvrir\n"}
-        {'de nouvelles !'}
-      </div>
-    </main>
-    <FormFooter
-      items={[
-        {
-          id: 'sign-up-link',
-          label: 'Créer un compte',
-          url: '/verification-eligibilite',
-          tracker: trackSignup,
-        },
-        {
-          id: 'sign-in-link',
-          label: "Me connecter",
-          url: '/connexion',
-        },
-      ]}
-    />
-  </div>
-)
+const BetaPage = ({ trackSignup, isNewBookingLimitsActived, wholeFranceOpening }) => {
+  const appTitle = useRef(null)
+
+  useEffect(() => {
+    appTitle.current.focus()
+  }, [])
+
+  return (
+    <div className="beta-page">
+      <Icon
+        alt=""
+        className="bp-logo"
+        svg="circle"
+      />
+      <main className="bp-main">
+        <div
+          className="bp-title"
+          ref={appTitle}
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          tabIndex={0}
+        >
+          {'Bienvenue dans\n'}
+          {'ton pass Culture'}
+        </div>
+        <div className="bp-content">
+          {'Tu as 18 ans'}
+          {!wholeFranceOpening && (
+            <span>
+              {' et tu vis dans un '}
+              <a
+                href="https://pass.culture.fr/le-dispositif/#dispoexpe"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {'département éligible'}
+              </a>
+            </span>
+          )}
+          {' ?'}
+        </div>
+        <div className="bp-content">
+          {`Bénéficie de ${isNewBookingLimitsActived ? 300 : 500} € afin de\n`}
+          {'renforcer tes pratiques\n'}
+          {"culturelles et d'en découvrir\n"}
+          {'de nouvelles !'}
+        </div>
+      </main>
+      <FormFooter
+        items={[
+          {
+            id: 'sign-up-link',
+            label: 'Créer un compte',
+            url: '/verification-eligibilite',
+            tracker: trackSignup,
+          },
+          {
+            id: 'sign-in-link',
+            label: 'Me connecter',
+            url: '/connexion',
+          },
+        ]}
+      />
+    </div>
+  )
+}
 
 BetaPage.propTypes = {
   isNewBookingLimitsActived: PropTypes.bool.isRequired,

--- a/src/styles/components/pages/beta-page/_BetaPage.scss
+++ b/src/styles/components/pages/beta-page/_BetaPage.scss
@@ -22,6 +22,10 @@
   margin-bottom: rem(32px);
   margin-top: rem(100px);
   white-space: pre-wrap;
+
+  &:focus {
+    outline: transparent;
+  }
 }
 
 .bp-content {


### PR DESCRIPTION
Ajout d'un tabindex=0 sur l'élément titre de la page Beta, avec un focus automatique sur celui-ci.
Ce n'est pas une bonne pratique de permettre à l'utilisateur de naviguer au clavier sur un élément non interactif, mais il existe des cas exceptionnels comme celui-ci où l'on peut passer "outre" la règle.
Afin que les utilisateurs voyants ne soient pas perturbé-es par cet outline bleu sur un élément texte, il a été rendu transparent (outline: none étant "interdit") pour ne pas attirer l'attention inutilement.

Le besoin est qu'il est nécessaire de signaler aux utilisateurs non voyants qu'ils sont bien arrivés sur la page alors que l'écran de chargement est présent, afin que ceux-ci ne perdent aucune information.