### PR TITLE
(PC-8174) utiliser le champ isBookable pour sélectionner les stocks réservables

### DIFF
--- a/src/redux/selectors/data/__specs__/stocksSelectors.spec.js
+++ b/src/redux/selectors/data/__specs__/stocksSelectors.spec.js
@@ -251,6 +251,7 @@ describe('selectBookables', () => {
             id: 'AB',
             offerId: 'AA',
             beginningDatetime: moment(),
+            isBookable: true,
           },
         ],
       },
@@ -272,8 +273,39 @@ describe('selectBookables', () => {
         offerId: 'AA',
         userHasAlreadyBookedThisDate: true,
         userHasCancelledThisDate: false,
+        isBookable: true,
       },
     ])
+  })
+
+  it('should not return stock when it is not bookable', () => {
+    // given
+    const state = {
+      data: {
+        bookings: [
+          {
+            stockId: 'AB',
+          },
+        ],
+        stocks: [
+          {
+            id: 'AB',
+            offerId: 'AA',
+            beginningDatetime: moment(),
+            isBookable: false,
+          },
+        ],
+      },
+    }
+    const offer = {
+      id: 'AA',
+    }
+
+    // when
+    const result = selectBookables(state, offer)
+
+    // then
+    expect(result).toStrictEqual([])
   })
 })
 
@@ -288,16 +320,19 @@ describe('selectBookablesWithoutDateNotAvailable', () => {
             id: 'AB',
             offerId: 'ZZ',
             remainingQuantity: 0,
+            isBookable: true,
           },
           {
             id: 'AC',
             offerId: 'AA',
             remainingQuantity: 1,
+            isBookable: true,
           },
           {
             id: 'AD',
             offerId: 'AA',
             remainingQuantity: 'unlimited',
+            isBookable: true,
           },
         ],
       },
@@ -318,6 +353,7 @@ describe('selectBookablesWithoutDateNotAvailable', () => {
         userHasAlreadyBookedThisDate: false,
         userHasCancelledThisDate: false,
         remainingQuantity: 1,
+        isBookable: true,
       },
       {
         __modifiers__: ['selectBookables'],
@@ -326,7 +362,38 @@ describe('selectBookablesWithoutDateNotAvailable', () => {
         userHasAlreadyBookedThisDate: false,
         userHasCancelledThisDate: false,
         remainingQuantity: 'unlimited',
+        isBookable: true,
       },
     ])
+  })
+
+  it('should not return stock when it is not bookable', () => {
+    // given
+    const state = {
+      data: {
+        bookings: [
+          {
+            stockId: 'AB',
+          },
+        ],
+        stocks: [
+          {
+            id: 'AD',
+            offerId: 'AA',
+            remainingQuantity: 'unlimited',
+            isBookable: false,
+          },
+        ],
+      },
+    }
+    const offer = {
+      id: 'AA',
+    }
+
+    // when
+    const result = selectBookablesWithoutDateNotAvailable(state, offer)
+
+    // then
+    expect(result).toStrictEqual([])
   })
 })

--- a/src/redux/selectors/data/stocksSelectors.js
+++ b/src/redux/selectors/data/stocksSelectors.js
@@ -25,6 +25,12 @@ export const selectStocksByOfferId = createCachedSelector(
   (stocks, offerId) => stocks.filter(stock => stock.offerId === offerId)
 )((state, offerId = '') => offerId)
 
+export const selectBookableStocks = createCachedSelector(
+  (state, offerId) => offerId,
+  selectStocksByOfferId,
+  (offerId, stocks) => stocks.filter(stock => stock.isBookable)
+)((state, offerId = '') => offerId)
+
 export const selectIsEnoughStockForOfferDuo = createCachedSelector(
   (state, offerId) => offerId,
   selectStocksByOfferId,
@@ -55,7 +61,7 @@ export const selectBookables = createCachedSelector(
   (state, offer) => offer,
   (bookings, allStocks, offer) => {
     let { venue } = offer || {}
-    const stocks = selectStocksByOfferId({ data: { stocks: allStocks } }, offer && offer.id)
+    const stocks = selectBookableStocks({ data: { stocks: allStocks } }, offer && offer.id)
     const { departementCode } = venue || {}
     const tz = getTimezone(departementCode)
 
@@ -81,7 +87,7 @@ export const selectBookablesWithoutDateNotAvailable = createCachedSelector(
   (state, offer) => offer,
   (bookings, allStocks, offer) => {
     let { venue } = offer || {}
-    const stocks = selectStocksByOfferId({ data: { stocks: allStocks } }, offer && offer.id)
+    const stocks = selectBookableStocks({ data: { stocks: allStocks } }, offer && offer.id)
     const { departementCode } = venue || {}
     const tz = getTimezone(departementCode)
 


### PR DESCRIPTION
Lien des tickets : 
https://passculture.atlassian.net/browse/PC-8174
https://passculture.atlassian.net/browse/PC-8186

Les dates des stocks supprimés côté pro étaient proposés à la réservation sur le détail de l'offre et le calendrier :
![Screenshot from 2021-04-21 16-08-50](https://user-images.githubusercontent.com/22886846/115574221-bbea1480-a2c1-11eb-8b09-95e3304bb862.png)

En utilisant le champ isBookable on a seulement les dates réservables :
![Screenshot from 2021-04-21 16-09-55](https://user-images.githubusercontent.com/22886846/115574252-c1dff580-a2c1-11eb-8c86-6eebc6352fc0.png)
