### PR TITLE
(PC-7587): Add white-space css property to broke line at newline characters in VersoContentOffer info's

### DIFF
--- a/src/styles/components/layout/Verso/_Verso.scss
+++ b/src/styles/components/layout/Verso/_Verso.scss
@@ -60,6 +60,7 @@
 
     .verso-info-block {
       margin-top: rem(12px);
+      white-space: pre-line;
 
       h3 {
         color: $primary;


### PR DESCRIPTION
Ajout de la propriété css `white-space: pre-line;` à `.verso-info-block` pour ne pas regrouper les sauts de ligne comme les séries de blancs pour les infos d'une offre, notamment ce qui sont rempli par l'acteur via une `<textarea/>` (ex: Modalités de retrait).

Avant :
![image](https://user-images.githubusercontent.com/77629406/116710047-9cde3780-a9d1-11eb-9bb3-d77b23d26ec0.png)


Après:
![image](https://user-images.githubusercontent.com/77629406/116710138-b67f7f00-a9d1-11eb-87f2-8407dae62cf9.png)
